### PR TITLE
fix: strip markdown code fences from Claude JSON responses

### DIFF
--- a/router/src/__tests__/json-utils.test.ts
+++ b/router/src/__tests__/json-utils.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for JSON utilities
+ */
+
+import { describe, it, expect } from 'vitest';
+import { stripJsonCodeFences, parseJsonResponse } from '../agents/json-utils.js';
+
+describe('stripJsonCodeFences', () => {
+  it('should return raw JSON unchanged', () => {
+    const json = '{"findings": []}';
+    expect(stripJsonCodeFences(json)).toBe(json);
+  });
+
+  it('should strip ```json ... ``` fences', () => {
+    const fenced = '```json\n{"findings": []}\n```';
+    expect(stripJsonCodeFences(fenced)).toBe('{"findings": []}');
+  });
+
+  it('should strip ``` ... ``` fences (no language tag)', () => {
+    const fenced = '```\n{"findings": []}\n```';
+    expect(stripJsonCodeFences(fenced)).toBe('{"findings": []}');
+  });
+
+  it('should handle whitespace around fences', () => {
+    const fenced = '  ```json\n  {"findings": []}\n  ```  ';
+    expect(stripJsonCodeFences(fenced)).toBe('{"findings": []}');
+  });
+
+  it('should preserve inner code blocks (surgical behavior)', () => {
+    const withInner = '```json\n{"code": "```nested```"}\n```';
+    const result = stripJsonCodeFences(withInner);
+    expect(result).toBe('{"code": "```nested```"}');
+  });
+
+  it('should handle multiline JSON content', () => {
+    const fenced = '```json\n{\n  "findings": [\n    {"severity": "high"}\n  ]\n}\n```';
+    const result = stripJsonCodeFences(fenced);
+    expect(result).toContain('"findings"');
+    expect(result).toContain('"severity"');
+  });
+
+  it('should return malformed content unchanged (opening fence, no closing)', () => {
+    const malformed = '```json\n{"findings": []}';
+    expect(stripJsonCodeFences(malformed)).toBe(malformed);
+  });
+
+  it('should return content with no opening fence unchanged', () => {
+    const noOpening = '{"findings": []}\n```';
+    expect(stripJsonCodeFences(noOpening)).toBe(noOpening.trim());
+  });
+});
+
+describe('parseJsonResponse', () => {
+  it('should parse raw JSON', () => {
+    const json = '{"findings": []}';
+    const result = parseJsonResponse(json, 'Test');
+    expect(result).toEqual({ findings: [] });
+  });
+
+  it('should parse fenced JSON', () => {
+    const fenced = '```json\n{"findings": []}\n```';
+    const result = parseJsonResponse(fenced, 'Anthropic');
+    expect(result).toEqual({ findings: [] });
+  });
+
+  it('should throw descriptive error for invalid JSON', () => {
+    const invalid = '```json\nnot valid json\n```';
+    expect(() => parseJsonResponse(invalid, 'Anthropic')).toThrow(
+      /Failed to parse Anthropic response as JSON/
+    );
+  });
+
+  it('should include content preview in error message', () => {
+    const invalid = '```json\nthis is not json\n```';
+    expect(() => parseJsonResponse(invalid, 'Test')).toThrow(/this is not json/);
+  });
+
+  it('should throw for empty content', () => {
+    expect(() => parseJsonResponse('', 'Test')).toThrow();
+  });
+
+  it('should throw for whitespace-only content', () => {
+    expect(() => parseJsonResponse('   \n   ', 'Test')).toThrow();
+  });
+});

--- a/router/src/agents/ai_semantic_review.ts
+++ b/router/src/agents/ai_semantic_review.ts
@@ -18,6 +18,7 @@ import type { ReviewAgent, AgentContext, AgentResult, Finding, Severity } from '
 import type { DiffFile } from '../diff.js';
 import { estimateTokens } from '../budget.js';
 import { buildAgentEnv } from './security.js';
+import { parseJsonResponse } from './json-utils.js';
 import { withRetry } from './retry.js';
 
 const SUPPORTED_EXTENSIONS = [
@@ -109,13 +110,8 @@ async function runWithAnthropic(
       throw new Error('No text content in Anthropic response');
     }
 
-    // Parse and validate JSON
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(textContent.text);
-    } catch {
-      throw new Error(`Invalid JSON from Anthropic: ${textContent.text.slice(0, 200)}`);
-    }
+    // Parse and validate JSON (handles Claude's code fence wrapping)
+    const parsed = parseJsonResponse(textContent.text, 'Anthropic');
 
     const result = SemanticResponseSchema.safeParse(parsed);
     if (!result.success) {

--- a/router/src/agents/json-utils.ts
+++ b/router/src/agents/json-utils.ts
@@ -1,0 +1,67 @@
+/**
+ * JSON Utilities for LLM Response Parsing
+ *
+ * LLMs (especially Claude) often wrap JSON responses in markdown code fences.
+ * This module provides surgical utilities to handle this without hiding errors.
+ */
+
+/**
+ * Strip leading/trailing markdown code fences from text.
+ *
+ * SURGICAL: Only removes fences at the very start and end of the text.
+ * Does NOT modify inner content or embedded code blocks.
+ *
+ * Handles:
+ * - ```json ... ```
+ * - ``` ... ```
+ * - Raw JSON (no fences)
+ *
+ * @param text - Raw text from LLM response
+ * @returns Text with leading/trailing fences removed
+ */
+export function stripJsonCodeFences(text: string): string {
+  const trimmed = text.trim();
+
+  // Check for opening fence at the very start
+  const openingFenceMatch = trimmed.match(/^```(?:json)?\s*\n?/);
+  if (!openingFenceMatch) {
+    // No opening fence - return as-is
+    return trimmed;
+  }
+
+  // Check for closing fence at the very end
+  const closingFenceMatch = trimmed.match(/\n?```\s*$/);
+  if (!closingFenceMatch) {
+    // Opening fence but no closing fence - malformed, return as-is
+    return trimmed;
+  }
+
+  // Extract content between fences
+  const startIndex = openingFenceMatch[0].length;
+  const endIndex = trimmed.length - closingFenceMatch[0].length;
+
+  return trimmed.slice(startIndex, endIndex).trim();
+}
+
+/**
+ * Parse JSON from LLM response, handling code fences.
+ *
+ * Strips fences first, then parses. On parse failure, throws with
+ * descriptive error including raw content preview for debugging.
+ *
+ * @param text - Raw text from LLM response
+ * @param context - Context for error message (e.g., "Anthropic", "OpenAI")
+ * @returns Parsed JSON value
+ * @throws Error with descriptive message if parsing fails
+ */
+export function parseJsonResponse(text: string, context: string): unknown {
+  const cleaned = stripJsonCodeFences(text);
+
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    // Include raw content preview for debugging
+    const preview = cleaned.slice(0, 200).replace(/\n/g, '\\n');
+    throw new Error(`Failed to parse ${context} response as JSON: "${preview}..."`);
+  }
+}


### PR DESCRIPTION
Claude models wrap JSON responses in markdown code fences (\\\json ... \\\). This caused 'Invalid JSON from Anthropic' errors even though the API call succeeded.

Changes:
- Add json-utils.ts with surgical stripJsonCodeFences() utility
- Add parseJsonResponse() that strips fences before parsing
- Update opencode.ts, pr_agent.ts, ai_semantic_review.ts to use parseJsonResponse
- Add comprehensive unit tests for json-utils

The fence stripping is surgical - only removes leading/trailing fences, preserves inner content. Parse failures remain hard failures.

280 tests passing (+14 new)