### PR TITLE
fix(local_llm): reduce default context to 8192, increase timeout to 180s

### DIFF
--- a/docs/LOCAL-LLM-SETUP.md
+++ b/docs/LOCAL-LLM-SETUP.md
@@ -13,8 +13,8 @@ The `local_llm` agent uses Ollama for air-gapped, local AI code review. This gui
 | `OLLAMA_BASE_URL`    | No       | `http://ollama-sidecar:11434` | Ollama API endpoint          |
 | `OLLAMA_MODEL`       | No       | `codellama:7b`                | Model to use for review      |
 | `LOCAL_LLM_OPTIONAL` | No       | `false`                       | Enable graceful degradation  |
-| `LOCAL_LLM_NUM_CTX`  | No       | `16384`                       | Context window size (tokens) |
-| `LOCAL_LLM_TIMEOUT`  | No       | `120000`                      | Request timeout (ms)         |
+| `LOCAL_LLM_NUM_CTX`  | No       | `8192`                        | Context window size (tokens) |
+| `LOCAL_LLM_TIMEOUT`  | No       | `180000`                      | Request timeout (ms)         |
 
 ### Example Configuration
 
@@ -23,7 +23,7 @@ The `local_llm` agent uses Ollama for air-gapped, local AI code review. This gui
 env:
   OLLAMA_BASE_URL: http://ollama:11434
   OLLAMA_MODEL: codellama:7b
-  LOCAL_LLM_NUM_CTX: 16384 # Context window (increase for larger diffs)
+  LOCAL_LLM_NUM_CTX: 8192 # Context window (default; increase for larger diffs if VRAM allows)
   LOCAL_LLM_TIMEOUT: 180000 # 3 minutes (for slower models)
   # LOCAL_LLM_OPTIONAL: true     # Uncomment for graceful degradation
 ```
@@ -89,8 +89,8 @@ The agent enforces these limits to prevent timeouts:
 - **Max files:** 50 (alphabetically sorted)
 - **Max diff lines:** 2000
 - **Max tokens:** 8192 (pre-flight check)
-- **Context window:** 16384 (configurable via `LOCAL_LLM_NUM_CTX`)
-- **Timeout:** 120 seconds (configurable via `LOCAL_LLM_TIMEOUT`)
+- **Context window:** 8192 (configurable via `LOCAL_LLM_NUM_CTX`)
+- **Timeout:** 180 seconds (configurable via `LOCAL_LLM_TIMEOUT`)
 
 ## Running with OSCR
 
@@ -129,7 +129,7 @@ See [OSCR Integration Guide](./OSCR-INTEGRATION.md) for conceptual overview.
 
 ### Timeout Errors
 
-**Problem:** Reviews exceed timeout (default 120s)
+**Problem:** Reviews exceed timeout (default 180s)
 
 **Solutions:**
 
@@ -147,7 +147,7 @@ See [OSCR Integration Guide](./OSCR-INTEGRATION.md) for conceptual overview.
 
 **Solutions:**
 
-1. Increase context window: `LOCAL_LLM_NUM_CTX=16384` (or higher if RAM allows)
+1. Increase context window: `LOCAL_LLM_NUM_CTX=16384` (if VRAM allows; default is 8192)
 2. Reduce diff size via path filters in config
 3. Check Ollama logs for exact token counts: `docker logs <ollama-container>`
 

--- a/router/src/__tests__/local_llm.test.ts
+++ b/router/src/__tests__/local_llm.test.ts
@@ -525,7 +525,7 @@ describe('localLlmAgent', () => {
       vi.restoreAllMocks();
     });
 
-    it('should use default num_ctx of 16384 when LOCAL_LLM_NUM_CTX not set', async () => {
+    it('should use default num_ctx of 8192 when LOCAL_LLM_NUM_CTX not set', async () => {
       let capturedBody: string | undefined;
       global.fetch = vi.fn().mockImplementation((_url: string, options: RequestInit) => {
         capturedBody = options.body as string;
@@ -564,7 +564,7 @@ describe('localLlmAgent', () => {
 
       expect(capturedBody).toBeDefined();
       const parsed = JSON.parse(capturedBody as string);
-      expect(parsed.options.num_ctx).toBe(16384);
+      expect(parsed.options.num_ctx).toBe(8192);
     });
 
     it('should use custom num_ctx when LOCAL_LLM_NUM_CTX is set', async () => {
@@ -611,7 +611,7 @@ describe('localLlmAgent', () => {
       expect(parsed.options.num_ctx).toBe(32768);
     });
 
-    it('should use default timeout of 120000ms when LOCAL_LLM_TIMEOUT not set', async () => {
+    it('should use default timeout of 180000ms when LOCAL_LLM_TIMEOUT not set', async () => {
       // Use a spy to capture the AbortController timeout
       const originalFetch = global.fetch;
       let abortSignalReceived = false;

--- a/router/src/agents/local_llm.ts
+++ b/router/src/agents/local_llm.ts
@@ -43,8 +43,8 @@ const MAX_DIFF_LINES = 2000;
 const MAX_TOKENS = 8192;
 /** Default timeout for Ollama requests (180 seconds - codellama:7b can take up to 2 min) */
 const DEFAULT_TIMEOUT_MS = 180000;
-/** Default context window size (16k tokens) */
-const DEFAULT_NUM_CTX = 16384;
+/** Default context window size (8k tokens - balances capability vs VRAM usage) */
+const DEFAULT_NUM_CTX = 8192;
 /** Default Ollama model */
 const DEFAULT_MODEL = 'codellama:7b';
 


### PR DESCRIPTION
- Context 16384 uses 8GB KV cache, filling 16GB GPU
- 8192 context halves VRAM usage for faster inference
- Increased timeout to 180s as safety margin
- codellama:7b was taking ~3 min with 16k context