### PR TITLE
fix: clarify model-driven provider selection and add tests

### DIFF
--- a/docs/GITHUB-MAX.md
+++ b/docs/GITHUB-MAX.md
@@ -206,7 +206,12 @@ Required secrets:
 
 ### Mixed Providers
 
-You can set multiple API keys. The router selects providers with this priority:
+You can set multiple API keys. The router selects providers based on the configured model when it can infer a match:
+
+- **claude-\*** models use **Anthropic** (requires `ANTHROPIC_API_KEY`).
+- **gpt-\***/**o1-\*** models use **OpenAI** (requires `OPENAI_API_KEY` or Azure bundle).
+
+If the model prefix is unknown, the router falls back to this priority:
 
 1. **Anthropic** (if `ANTHROPIC_API_KEY` set and agent supports it)
 2. **Azure OpenAI** (if all three Azure vars set and agent supports it)

--- a/router/src/main.ts
+++ b/router/src/main.ts
@@ -334,7 +334,11 @@ async function runReview(options: ReviewOptions): Promise<void> {
         const scopedContext: AgentContext = {
           ...agentContext,
           env: buildAgentEnv(agent.id, routerEnv),
-          provider: resolveProvider(agent.id as Parameters<typeof resolveProvider>[0], routerEnv),
+          provider: resolveProvider(
+            agent.id as Parameters<typeof resolveProvider>[0],
+            routerEnv,
+            agentContext.effectiveModel
+          ),
         };
 
         let result: AgentResult | null = null;


### PR DESCRIPTION
### Motivation
- Prevent incorrect provider routing when multiple API keys are present by making provider resolution honor the configured model (e.g., `gpt-*` → OpenAI, `claude-*` → Anthropic) so models like `gpt-4o-mini` are not mistakenly sent to Anthropic causing 404s. 
- Add explicit tests and documentation so the model→provider behavior and Azure edge cases are clear and covered.

### Description
- Updated `resolveProvider` in `router/src/config.ts` to accept an optional `model?: string` and prefer `inferProviderFromModel(model)` when the model prefix is known, returning `null` when the inferred provider lacks keys or agent capability. 
- Passed `agentContext.effectiveModel` into `resolveProvider` in `router/src/main.ts` so per-agent resolution uses the resolved model. 
- Added unit tests in `router/src/__tests__/config.test.ts` covering model-driven preferences, fallback priority, Azure-only key behavior, and non-Azure agent null-return cases. 
- Clarified selection behavior in `docs/GITHUB-MAX.md` and tidied related comments in `router/src/config.ts` to document model-driven selection and the fallback priority.

### Testing
- Ran `npm run test`, the Vitest suite completed successfully with `339 passed, 3 skipped`. 
- Ran `npm run lint` and formatting (`prettier --write` where needed), and linting completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973c6935a848333864d091594419ec0)