### PR TITLE
Support model-based provider selection when both API keys present

### DIFF
--- a/router/src/__tests__/preflight.test.ts
+++ b/router/src/__tests__/preflight.test.ts
@@ -380,31 +380,25 @@ describe('validateModelProviderMatch', () => {
     });
   });
 
-  describe('Provider precedence mismatch', () => {
-    it('should FAIL when gpt model + both OPENAI_API_KEY and ANTHROPIC_API_KEY set', () => {
-      // This is the critical bug fix: Anthropic wins due to precedence,
-      // so gpt-4o-mini would be sent to Anthropic API and get 404
+  describe('Both keys present (model-based provider selection)', () => {
+    it('should PASS when gpt model + both OPENAI_API_KEY and ANTHROPIC_API_KEY set', () => {
+      // When both keys are present, resolveProvider uses model to select correct provider
       const result = validateModelProviderMatch(createCloudAiConfig(), 'gpt-4o-mini', {
         OPENAI_API_KEY: 'sk-openai',
         ANTHROPIC_API_KEY: 'sk-ant-test',
       });
-      expect(result.valid).toBe(false);
-      expect(result.errors[0]).toContain('OpenAI model');
-      expect(result.errors[0]).toContain('Anthropic provider');
-      expect(result.errors[0]).toContain('takes precedence');
+      expect(result.valid).toBe(true);
     });
 
-    it('should FAIL when o1 model + both keys set (Anthropic wins)', () => {
+    it('should PASS when o1 model + both keys set', () => {
       const result = validateModelProviderMatch(createCloudAiConfig(), 'o1-preview', {
         OPENAI_API_KEY: 'sk-openai',
         ANTHROPIC_API_KEY: 'sk-ant-test',
       });
-      expect(result.valid).toBe(false);
-      expect(result.errors[0]).toContain('OpenAI model');
-      expect(result.errors[0]).toContain('Anthropic provider');
+      expect(result.valid).toBe(true);
     });
 
-    it('should PASS when claude model + both keys set (Anthropic expected and selected)', () => {
+    it('should PASS when claude model + both keys set', () => {
       const result = validateModelProviderMatch(createCloudAiConfig(), 'claude-sonnet-4-20250514', {
         OPENAI_API_KEY: 'sk-openai',
         ANTHROPIC_API_KEY: 'sk-ant-test',
@@ -412,21 +406,18 @@ describe('validateModelProviderMatch', () => {
       expect(result.valid).toBe(true);
     });
 
-    it('should PASS when gpt model + only OPENAI_API_KEY set (no precedence issue)', () => {
+    it('should PASS when gpt model + only OPENAI_API_KEY set', () => {
       const result = validateModelProviderMatch(createCloudAiConfig(), 'gpt-4o-mini', {
         OPENAI_API_KEY: 'sk-openai',
       });
       expect(result.valid).toBe(true);
     });
 
-    it('error message includes actionable fix suggestions', () => {
-      const result = validateModelProviderMatch(createCloudAiConfig(), 'gpt-4o-mini', {
-        OPENAI_API_KEY: 'sk-openai',
+    it('should PASS when claude model + only ANTHROPIC_API_KEY set', () => {
+      const result = validateModelProviderMatch(createCloudAiConfig(), 'claude-sonnet-4-20250514', {
         ANTHROPIC_API_KEY: 'sk-ant-test',
       });
-      expect(result.valid).toBe(false);
-      expect(result.errors[0]).toContain('MODEL=claude-sonnet');
-      expect(result.errors[0]).toContain('unset ANTHROPIC_API_KEY');
+      expect(result.valid).toBe(true);
     });
   });
 

--- a/router/src/main.ts
+++ b/router/src/main.ts
@@ -334,7 +334,11 @@ async function runReview(options: ReviewOptions): Promise<void> {
         const scopedContext: AgentContext = {
           ...agentContext,
           env: buildAgentEnv(agent.id, routerEnv),
-          provider: resolveProvider(agent.id as Parameters<typeof resolveProvider>[0], routerEnv),
+          provider: resolveProvider(
+            agent.id as Parameters<typeof resolveProvider>[0],
+            routerEnv,
+            agentContext.effectiveModel
+          ),
         };
 
         let result: AgentResult | null = null;

--- a/router/src/preflight.ts
+++ b/router/src/preflight.ts
@@ -10,7 +10,6 @@
  */
 
 import type { Config, AgentId } from './config.js';
-import { resolveProvider, inferProviderFromModel } from './config.js';
 
 export interface PreflightResult {
   valid: boolean;
@@ -181,13 +180,15 @@ export function validateModelConfig(
 const CLOUD_AI_AGENTS: AgentId[] = ['opencode', 'pr_agent', 'ai_semantic_review'];
 
 /**
- * Validate model-provider match based on model name heuristic AND provider resolution.
- * Fails if:
- * 1. Model looks like it requires a specific provider but key is missing
- * 2. Model requires one provider but a different provider will be selected due to precedence
+ * Validate model-provider match based on model name heuristic.
+ * Fails if model looks like it requires a specific provider but key is missing.
  *
  * ONLY validates when cloud AI agents (opencode, pr_agent, ai_semantic_review) are enabled.
  * local_llm uses OLLAMA_MODEL, not MODEL, so it's excluded.
+ *
+ * NOTE: When both ANTHROPIC_API_KEY and OPENAI_API_KEY are present, resolveProvider()
+ * will select the correct provider based on the model name. This validation only
+ * checks that the required key exists.
  *
  * This is a heuristic, not a contract. Error messages are explicit about the inference.
  */
@@ -198,18 +199,12 @@ export function validateModelProviderMatch(
 ): PreflightResult {
   const errors: string[] = [];
 
-  // Collect enabled cloud AI agents
-  const enabledCloudAgents: AgentId[] = [];
-  for (const pass of config.passes) {
-    if (!pass.enabled) continue;
-    for (const agentId of pass.agents) {
-      if (CLOUD_AI_AGENTS.includes(agentId) && !enabledCloudAgents.includes(agentId)) {
-        enabledCloudAgents.push(agentId);
-      }
-    }
-  }
+  // Only validate if cloud AI agents are enabled
+  const hasCloudAiAgent = config.passes.some(
+    (pass) => pass.enabled && pass.agents.some((a) => CLOUD_AI_AGENTS.includes(a))
+  );
 
-  if (enabledCloudAgents.length === 0) {
+  if (!hasCloudAiAgent) {
     // No cloud AI agents enabled, skip model-provider validation
     return { valid: true, errors: [] };
   }
@@ -227,41 +222,21 @@ export function validateModelProviderMatch(
     return { valid: false, errors };
   }
 
-  // Infer which provider the model requires
-  const inferredProvider = inferProviderFromModel(model);
-
-  // Basic validation: check if the inferred provider's key exists
-  if (inferredProvider === 'anthropic') {
+  // Heuristic: infer provider from model prefix
+  if (model.startsWith('claude-')) {
     if (!env['ANTHROPIC_API_KEY']) {
       errors.push(
         `MODEL '${model}' looks like Anthropic (claude-*) but ANTHROPIC_API_KEY is missing`
       );
     }
-  } else if (inferredProvider === 'openai') {
+  } else if (model.startsWith('gpt-') || model.startsWith('o1-')) {
     const hasOpenAI = env['OPENAI_API_KEY'] || env['AZURE_OPENAI_API_KEY'];
     if (!hasOpenAI) {
       errors.push(`MODEL '${model}' looks like OpenAI (gpt-*/o1-*) but OPENAI_API_KEY is missing`);
     }
   }
-
-  // CRITICAL: Check for provider precedence mismatch
-  // When both keys are present, Anthropic wins due to precedence rules.
-  // If model requires OpenAI but Anthropic will be selected, fail fast.
-  if (inferredProvider === 'openai') {
-    for (const agentId of enabledCloudAgents) {
-      const resolvedProvider = resolveProvider(agentId, env);
-      if (resolvedProvider === 'anthropic') {
-        errors.push(
-          `MODEL '${model}' is an OpenAI model but agent '${agentId}' will use Anthropic provider ` +
-            `(ANTHROPIC_API_KEY is set and takes precedence).\n` +
-            `Fix: Either:\n` +
-            `  - Use an Anthropic model: MODEL=claude-sonnet-4-20250514\n` +
-            `  - Or unset ANTHROPIC_API_KEY to use OpenAI provider`
-        );
-        break; // One error is enough
-      }
-    }
-  }
+  // Unknown model prefix - no validation, allow it to proceed
+  // When both keys are present, resolveProvider() uses the model to select the right provider
 
   return {
     valid: errors.length === 0,


### PR DESCRIPTION
## Summary
This PR enhances the provider resolution logic to intelligently select between OpenAI and Anthropic based on the model name when both API keys are present, rather than always defaulting to Anthropic.

## Key Changes

- **Updated `resolveProvider()` function**: Now accepts an optional `model` parameter and uses it to infer the correct provider when both keys are available
  - If model is `gpt-*` or `o1-*` and OpenAI key exists → use OpenAI
  - If model is `claude-*` and Anthropic key exists → use Anthropic
  - Falls back to precedence-based selection (Anthropic) for unknown models or when no model specified

- **Updated `runReview()` in main.ts**: Passes the `effectiveModel` to `resolveProvider()` to enable model-based selection

- **Enhanced test coverage**: 
  - Added comprehensive test suite for `resolveProvider()` covering model-based selection, single key scenarios, fallback precedence, and special agents
  - Added integration tests in `validateModelProviderMatch()` to verify the new behavior works correctly with both keys present

- **Updated documentation**: Clarified the new invariants in code comments explaining the precedence rules

## Implementation Details

The change maintains backward compatibility while improving the user experience:
- When only one key is present, behavior is unchanged
- When both keys are present, the model name now drives the provider selection
- Special agents (local_llm, semgrep, reviewdog) continue to work as before
- The validation logic in preflight checks now accounts for model-based selection