### PR TITLE
Add diff line validation for inline code review comments

### DIFF
--- a/router/src/__tests__/diff_line_validator.test.ts
+++ b/router/src/__tests__/diff_line_validator.test.ts
@@ -1,0 +1,604 @@
+/**
+ * Diff Line Validator Tests
+ *
+ * These tests ensure that the diff line validation logic correctly:
+ * 1. Parses unified diff hunks to extract valid line ranges
+ * 2. Validates finding line numbers against diff context
+ * 3. Suggests nearest valid lines when validation fails
+ * 4. Handles edge cases (empty diffs, deleted files, etc.)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseDiffHunks,
+  buildDiffLineMap,
+  validateFindingLine,
+  filterValidFindings,
+  findNearestValidLine,
+  getFileDiffSummary,
+} from '../diff_line_validator.js';
+import type { DiffFile } from '../diff.js';
+
+describe('parseDiffHunks', () => {
+  it('should parse a simple hunk with additions and deletions', () => {
+    const patch = `diff --git a/src/utils.ts b/src/utils.ts
+index abc123..def456 100644
+--- a/src/utils.ts
++++ b/src/utils.ts
+@@ -10,5 +10,6 @@ function helper() {
+   const a = 1;
+-  const b = 2;
++  const b = 3;
++  const c = 4;
+   return a + b;
+ }`;
+
+    const hunks = parseDiffHunks(patch);
+
+    expect(hunks).toHaveLength(1);
+    expect(hunks[0]).toMatchObject({
+      oldStart: 10,
+      oldCount: 5,
+      newStart: 10,
+      newCount: 6,
+    });
+
+    // Context line 10 (const a = 1)
+    // Line 11 was deleted (const b = 2) - not in new file
+    // Line 11 in new file is the addition (const b = 3)
+    // Line 12 in new file is the addition (const c = 4)
+    // Line 13 in new file is context (return a + b)
+    // Line 14 in new file is context (})
+    expect(hunks[0]?.newFileLines).toEqual([10, 11, 12, 13, 14]);
+    expect(hunks[0]?.addedLines).toEqual([11, 12]);
+    expect(hunks[0]?.contextLines).toEqual([10, 13, 14]);
+  });
+
+  it('should parse multiple hunks', () => {
+    const patch = `@@ -1,3 +1,4 @@
++// Header comment
+ const a = 1;
+ const b = 2;
+ const c = 3;
+@@ -20,3 +21,4 @@ function test() {
+   return true;
++  // New line
+ }`;
+
+    const hunks = parseDiffHunks(patch);
+
+    expect(hunks).toHaveLength(2);
+
+    // First hunk: adding header comment
+    expect(hunks[0]).toMatchObject({
+      oldStart: 1,
+      oldCount: 3,
+      newStart: 1,
+      newCount: 4,
+    });
+    expect(hunks[0]?.addedLines).toEqual([1]);
+
+    // Second hunk: adding comment in function
+    // @@ -20,3 +21,4 @@ means: starts at line 21 in new file
+    // Line 21: context (  return true;)
+    // Line 22: added (+  // New line)
+    // Line 23: context (})
+    expect(hunks[1]).toMatchObject({
+      oldStart: 20,
+      oldCount: 3,
+      newStart: 21,
+      newCount: 4,
+    });
+    expect(hunks[1]?.addedLines).toEqual([22]);
+  });
+
+  it('should handle hunks with only additions (new file)', () => {
+    const patch = `@@ -0,0 +1,5 @@
++// New file
++export function newFunc() {
++  return 42;
++}
++`;
+
+    const hunks = parseDiffHunks(patch);
+
+    expect(hunks).toHaveLength(1);
+    expect(hunks[0]).toMatchObject({
+      oldStart: 0,
+      oldCount: 0,
+      newStart: 1,
+      newCount: 5,
+    });
+    expect(hunks[0]?.addedLines).toEqual([1, 2, 3, 4, 5]);
+    expect(hunks[0]?.contextLines).toEqual([]);
+  });
+
+  it('should handle hunks with only deletions', () => {
+    const patch = `@@ -1,5 +1,2 @@
+ const a = 1;
+-const b = 2;
+-const c = 3;
+-const d = 4;
+ const e = 5;`;
+
+    const hunks = parseDiffHunks(patch);
+
+    expect(hunks).toHaveLength(1);
+    expect(hunks[0]?.newFileLines).toEqual([1, 2]);
+    expect(hunks[0]?.addedLines).toEqual([]);
+    expect(hunks[0]?.contextLines).toEqual([1, 2]);
+  });
+
+  it('should handle single-line hunk headers without count', () => {
+    // When count is 1, git omits it: @@ -10 +10 @@ instead of @@ -10,1 +10,1 @@
+    const patch = `@@ -10 +10 @@
+-old line
++new line`;
+
+    const hunks = parseDiffHunks(patch);
+
+    expect(hunks).toHaveLength(1);
+    expect(hunks[0]).toMatchObject({
+      oldStart: 10,
+      oldCount: 1,
+      newStart: 10,
+      newCount: 1,
+    });
+    expect(hunks[0]?.addedLines).toEqual([10]);
+  });
+
+  it('should return empty array for empty patch', () => {
+    expect(parseDiffHunks('')).toEqual([]);
+    expect(parseDiffHunks(undefined as unknown as string)).toEqual([]);
+  });
+
+  it('should handle "No newline at end of file" marker', () => {
+    const patch = `@@ -1,2 +1,2 @@
+ const a = 1;
+-const b = 2;
+\\ No newline at end of file
++const b = 3;
+\\ No newline at end of file`;
+
+    const hunks = parseDiffHunks(patch);
+
+    expect(hunks).toHaveLength(1);
+    expect(hunks[0]?.newFileLines).toEqual([1, 2]);
+    expect(hunks[0]?.addedLines).toEqual([2]);
+  });
+});
+
+describe('buildDiffLineMap', () => {
+  it('should build line map from multiple diff files', () => {
+    const files: DiffFile[] = [
+      {
+        path: 'src/index.ts',
+        status: 'modified',
+        additions: 2,
+        deletions: 1,
+        patch: `@@ -5,3 +5,4 @@
+ const x = 1;
+-const y = 2;
++const y = 3;
++const z = 4;
+ return x;`,
+      },
+      {
+        path: 'src/utils.ts',
+        status: 'added',
+        additions: 3,
+        deletions: 0,
+        patch: `@@ -0,0 +1,3 @@
++export const PI = 3.14;
++export const E = 2.71;
++export const PHI = 1.61;`,
+      },
+    ];
+
+    const lineMap = buildDiffLineMap(files);
+
+    expect(lineMap.files.size).toBe(2);
+
+    // Check index.ts
+    const indexLines = lineMap.files.get('src/index.ts');
+    expect(indexLines).toBeDefined();
+    expect(indexLines?.allLines.has(5)).toBe(true); // context
+    expect(indexLines?.allLines.has(6)).toBe(true); // added
+    expect(indexLines?.allLines.has(7)).toBe(true); // added
+    expect(indexLines?.allLines.has(8)).toBe(true); // context
+    expect(indexLines?.addedLines.has(6)).toBe(true);
+    expect(indexLines?.addedLines.has(7)).toBe(true);
+    expect(indexLines?.addedLines.has(5)).toBe(false);
+
+    // Check utils.ts (all added)
+    const utilsLines = lineMap.files.get('src/utils.ts');
+    expect(utilsLines?.allLines.size).toBe(3);
+    expect(utilsLines?.addedLines.size).toBe(3);
+  });
+
+  it('should skip deleted files', () => {
+    const files: DiffFile[] = [
+      {
+        path: 'deleted.ts',
+        status: 'deleted',
+        additions: 0,
+        deletions: 10,
+        patch: `@@ -1,10 +0,0 @@
+-// All content deleted`,
+      },
+    ];
+
+    const lineMap = buildDiffLineMap(files);
+
+    expect(lineMap.files.has('deleted.ts')).toBe(false);
+  });
+
+  it('should skip files without patches', () => {
+    const files: DiffFile[] = [
+      {
+        path: 'binary.png',
+        status: 'modified',
+        additions: 0,
+        deletions: 0,
+        // No patch for binary files
+      },
+    ];
+
+    const lineMap = buildDiffLineMap(files);
+
+    expect(lineMap.files.has('binary.png')).toBe(false);
+  });
+});
+
+describe('validateFindingLine', () => {
+  const files: DiffFile[] = [
+    {
+      path: 'src/app.ts',
+      status: 'modified',
+      additions: 3,
+      deletions: 1,
+      patch: `@@ -10,4 +10,6 @@ class App {
+   constructor() {
+-    this.init();
++    this.setup();
++    this.configure();
++    this.start();
+   }
+ }`,
+    },
+  ];
+
+  const lineMap = buildDiffLineMap(files);
+
+  it('should validate a line that exists in the diff', () => {
+    // Line 11 is an added line (this.setup())
+    const result = validateFindingLine('src/app.ts', 11, lineMap);
+
+    expect(result.valid).toBe(true);
+    expect(result.line).toBe(11);
+    expect(result.isAddition).toBe(true);
+  });
+
+  it('should validate a context line', () => {
+    // Line 10 is a context line (constructor() {)
+    const result = validateFindingLine('src/app.ts', 10, lineMap);
+
+    expect(result.valid).toBe(true);
+    expect(result.line).toBe(10);
+    expect(result.isAddition).toBe(false);
+  });
+
+  it('should reject a line not in the diff', () => {
+    // Line 5 is not in the diff context
+    const result = validateFindingLine('src/app.ts', 5, lineMap, { suggestNearest: true });
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('Line 5 is not in the diff');
+    expect(result.nearestValidLine).toBe(10); // Nearest valid line
+  });
+
+  it('should reject undefined line number', () => {
+    const result = validateFindingLine('src/app.ts', undefined, lineMap);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('undefined');
+  });
+
+  it('should reject zero or negative line numbers', () => {
+    const result0 = validateFindingLine('src/app.ts', 0, lineMap);
+    const resultNeg = validateFindingLine('src/app.ts', -5, lineMap);
+
+    expect(result0.valid).toBe(false);
+    expect(result0.reason).toContain('Invalid line number');
+
+    expect(resultNeg.valid).toBe(false);
+    expect(resultNeg.reason).toContain('Invalid line number');
+  });
+
+  it('should reject file not in diff', () => {
+    const result = validateFindingLine('src/other.ts', 10, lineMap);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('not found in diff');
+  });
+
+  it('should enforce additionsOnly option', () => {
+    // Line 10 is context, not an addition
+    const result = validateFindingLine('src/app.ts', 10, lineMap, { additionsOnly: true });
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('not an added line');
+  });
+
+  it('should pass with additionsOnly for added lines', () => {
+    // Line 12 is an added line (this.configure())
+    const result = validateFindingLine('src/app.ts', 12, lineMap, { additionsOnly: true });
+
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('findNearestValidLine', () => {
+  it('should return the same line if valid', () => {
+    const validLines = new Set([5, 10, 15, 20]);
+    expect(findNearestValidLine(10, validLines)).toBe(10);
+  });
+
+  it('should find nearest line below', () => {
+    const validLines = new Set([5, 10, 20]);
+    expect(findNearestValidLine(12, validLines)).toBe(10);
+  });
+
+  it('should find nearest line above', () => {
+    const validLines = new Set([5, 10, 20]);
+    expect(findNearestValidLine(18, validLines)).toBe(20);
+  });
+
+  it('should prefer closer line when equidistant', () => {
+    const validLines = new Set([10, 20]);
+    // Line 15 is equidistant from 10 and 20, should return 10 (first found)
+    const result = findNearestValidLine(15, validLines);
+    expect([10, 20]).toContain(result);
+  });
+
+  it('should return undefined for empty set', () => {
+    const validLines = new Set<number>();
+    expect(findNearestValidLine(10, validLines)).toBeUndefined();
+  });
+
+  it('should handle single valid line', () => {
+    const validLines = new Set([100]);
+    expect(findNearestValidLine(1, validLines)).toBe(100);
+    expect(findNearestValidLine(200, validLines)).toBe(100);
+  });
+});
+
+describe('filterValidFindings', () => {
+  const files: DiffFile[] = [
+    {
+      path: 'src/test.ts',
+      status: 'modified',
+      additions: 2,
+      deletions: 0,
+      patch: `@@ -10,2 +10,4 @@
+ context line 10
++added line 11
++added line 12
+ context line 13`,
+    },
+  ];
+
+  const lineMap = buildDiffLineMap(files);
+
+  it('should filter out findings with invalid lines', () => {
+    const findings = [
+      { file: 'src/test.ts', line: 10, message: 'valid context' },
+      { file: 'src/test.ts', line: 11, message: 'valid added' },
+      { file: 'src/test.ts', line: 5, message: 'invalid - not in diff' },
+      { file: 'src/other.ts', line: 10, message: 'invalid - wrong file' },
+    ];
+
+    const result = filterValidFindings(findings, lineMap);
+
+    expect(result.valid).toHaveLength(2);
+    expect(result.invalid).toHaveLength(2);
+    expect(result.stats).toEqual({
+      total: 4,
+      valid: 2,
+      invalid: 2,
+      autoFixed: 0,
+    });
+  });
+
+  it('should auto-fix lines when option enabled', () => {
+    const findings = [{ file: 'src/test.ts', line: 5, message: 'should be moved to line 10' }];
+
+    const result = filterValidFindings(findings, lineMap, { autoFixLines: true });
+
+    expect(result.valid).toHaveLength(1);
+    expect(result.valid[0]?.line).toBe(10); // Auto-fixed to nearest valid
+    expect(result.invalid).toHaveLength(0);
+    expect(result.stats.autoFixed).toBe(1);
+  });
+
+  it('should enforce additionsOnly when filtering', () => {
+    const findings = [
+      { file: 'src/test.ts', line: 10, message: 'context line' },
+      { file: 'src/test.ts', line: 11, message: 'added line' },
+    ];
+
+    const result = filterValidFindings(findings, lineMap, { additionsOnly: true });
+
+    expect(result.valid).toHaveLength(1);
+    expect(result.valid[0]?.line).toBe(11);
+    expect(result.invalid).toHaveLength(1);
+    expect(result.invalid[0]?.finding.line).toBe(10);
+  });
+
+  it('should handle empty findings array', () => {
+    const result = filterValidFindings([], lineMap);
+
+    expect(result.valid).toHaveLength(0);
+    expect(result.invalid).toHaveLength(0);
+    expect(result.stats.total).toBe(0);
+  });
+});
+
+describe('getFileDiffSummary', () => {
+  it('should generate readable summary', () => {
+    const files: DiffFile[] = [
+      {
+        path: 'src/app.ts',
+        status: 'modified',
+        additions: 3,
+        deletions: 0,
+        patch: `@@ -10,2 +10,5 @@
+ line 10
++line 11
++line 12
++line 13
+ line 14`,
+      },
+    ];
+
+    const lineMap = buildDiffLineMap(files);
+    const summary = getFileDiffSummary('src/app.ts', lineMap);
+
+    expect(summary).toContain('src/app.ts');
+    expect(summary).toContain('10-14');
+    expect(summary).toContain('11-13');
+    expect(summary).toContain('Hunks: 1');
+  });
+
+  it('should handle file not in diff', () => {
+    const lineMap = buildDiffLineMap([]);
+    const summary = getFileDiffSummary('not-found.ts', lineMap);
+
+    expect(summary).toContain('not in diff');
+  });
+});
+
+describe('real-world diff scenarios', () => {
+  it('should handle multi-hunk TypeScript diff', () => {
+    // Simplified two-hunk diff
+    const patch = `@@ -10,3 +10,5 @@ function helper() {
+ const a = 1;
+-const b = 2;
++const b = 3;
++const c = 4;
+ return a;
+@@ -50,2 +52,3 @@ function other() {
+ const x = 1;
++const y = 2;
+ return x;`;
+
+    const files: DiffFile[] = [
+      {
+        path: 'src/utils.ts',
+        status: 'modified',
+        additions: 3,
+        deletions: 1,
+        patch,
+      },
+    ];
+
+    const lineMap = buildDiffLineMap(files);
+    const fileLines = lineMap.files.get('src/utils.ts');
+
+    expect(fileLines).toBeDefined();
+
+    // First hunk starts at line 10
+    expect(fileLines?.allLines.has(10)).toBe(true); // context
+    expect(fileLines?.addedLines.has(11)).toBe(true); // const b = 3
+    expect(fileLines?.addedLines.has(12)).toBe(true); // const c = 4
+    expect(fileLines?.allLines.has(13)).toBe(true); // context
+
+    // Second hunk starts at line 52
+    expect(fileLines?.allLines.has(52)).toBe(true); // context
+    expect(fileLines?.addedLines.has(53)).toBe(true); // const y = 2
+    expect(fileLines?.allLines.has(54)).toBe(true); // context
+
+    // Line 30 should NOT be valid (between hunks)
+    expect(fileLines?.allLines.has(30)).toBe(false);
+
+    const validation = validateFindingLine('src/utils.ts', 30, lineMap, { suggestNearest: true });
+    expect(validation.valid).toBe(false);
+    expect(validation.nearestValidLine).toBeDefined();
+  });
+
+  it('should handle renamed file with modifications', () => {
+    // Simpler renamed file patch
+    const patch = `@@ -1,3 +1,4 @@
+ export class MyClass {
++  private initialized = false;
+   constructor() {}
+ }`;
+
+    const files: DiffFile[] = [
+      {
+        path: 'new_name.ts',
+        status: 'renamed',
+        additions: 1,
+        deletions: 0,
+        patch,
+      },
+    ];
+
+    const lineMap = buildDiffLineMap(files);
+
+    expect(lineMap.files.has('new_name.ts')).toBe(true);
+
+    const fileLines = lineMap.files.get('new_name.ts');
+    // Line 1: context (export class MyClass {)
+    // Line 2: added (private initialized = false;)
+    // Line 3: context (constructor() {})
+    // Line 4: context (})
+    expect(fileLines?.contextLines.has(1)).toBe(true);
+    expect(fileLines?.addedLines.has(2)).toBe(true);
+    expect(fileLines?.contextLines.has(3)).toBe(true);
+    expect(fileLines?.contextLines.has(4)).toBe(true);
+  });
+
+  it('should handle diff with large gap between hunks', () => {
+    const patch = `@@ -1,2 +1,3 @@
++// File header
+ const VERSION = "1.0";
+ const NAME = "app";
+@@ -100,2 +101,3 @@
+ // EOF
++// End marker
+ const LAST = true;`;
+
+    const files: DiffFile[] = [
+      {
+        path: 'large_file.ts',
+        status: 'modified',
+        additions: 2,
+        deletions: 0,
+        patch,
+      },
+    ];
+
+    const lineMap = buildDiffLineMap(files);
+    const fileLines = lineMap.files.get('large_file.ts');
+
+    // First hunk: lines 1-3
+    expect(fileLines?.addedLines.has(1)).toBe(true); // // File header
+    expect(fileLines?.contextLines.has(2)).toBe(true); // const VERSION
+    expect(fileLines?.contextLines.has(3)).toBe(true); // const NAME
+
+    // Second hunk: lines 101-103
+    expect(fileLines?.contextLines.has(101)).toBe(true); // // EOF
+    expect(fileLines?.addedLines.has(102)).toBe(true); // // End marker
+    expect(fileLines?.contextLines.has(103)).toBe(true); // const LAST
+
+    // Lines in the gap should NOT be valid
+    expect(fileLines?.allLines.has(50)).toBe(false);
+
+    const validation = validateFindingLine('large_file.ts', 50, lineMap, {
+      suggestNearest: true,
+    });
+    expect(validation.valid).toBe(false);
+    expect(validation.nearestValidLine).toBeDefined();
+  });
+});

--- a/router/src/__tests__/reporter_line_validation.test.ts
+++ b/router/src/__tests__/reporter_line_validation.test.ts
@@ -1,0 +1,654 @@
+/**
+ * Reporter Line Validation Tests
+ *
+ * These tests verify that GitHub and ADO reporters correctly validate
+ * line numbers against the diff before posting inline comments.
+ * This prevents comments from appearing on wrong lines or failing silently.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Config } from '../config.js';
+import type { Finding } from '../agents/index.js';
+import type { DiffFile } from '../diff.js';
+
+// Create mock functions for GitHub
+const mockChecksCreate = vi.fn();
+const mockChecksUpdate = vi.fn();
+const mockIssuesListComments = vi.fn();
+const mockIssuesCreateComment = vi.fn();
+const mockPullsListReviewComments = vi.fn();
+const mockPullsCreateReviewComment = vi.fn();
+
+// Mock Octokit
+vi.mock('@octokit/rest', () => ({
+  Octokit: vi.fn(() => ({
+    checks: {
+      create: mockChecksCreate,
+      update: mockChecksUpdate,
+    },
+    issues: {
+      listComments: mockIssuesListComments,
+      createComment: mockIssuesCreateComment,
+      updateComment: vi.fn().mockResolvedValue({ data: { id: 1 } }),
+    },
+    pulls: {
+      listReviewComments: mockPullsListReviewComments,
+      createReviewComment: mockPullsCreateReviewComment,
+    },
+  })),
+}));
+
+// Dynamic import after mock is set up
+const { reportToGitHub } = await import('../report/github.js');
+const { reportToADO } = await import('../report/ado.js');
+type GitHubContext = Parameters<typeof reportToGitHub>[1];
+type ADOContext = Parameters<typeof reportToADO>[1];
+
+describe('GitHub Reporter Line Validation', () => {
+  const diffFiles: DiffFile[] = [
+    {
+      path: 'src/utils.ts',
+      status: 'modified',
+      additions: 3,
+      deletions: 1,
+      patch: `@@ -10,4 +10,6 @@ function helper() {
+ const a = 1;
+-const b = 2;
++const b = 3;
++const c = 4;
+ return a;
+ }`,
+    },
+    {
+      path: 'src/new-file.ts',
+      status: 'added',
+      additions: 5,
+      deletions: 0,
+      patch: `@@ -0,0 +1,5 @@
++export function newFunc() {
++  const x = 1;
++  const y = 2;
++  return x + y;
++}`,
+    },
+  ];
+
+  const baseContext: GitHubContext = {
+    owner: 'test-owner',
+    repo: 'test-repo',
+    prNumber: 123,
+    headSha: 'abc123',
+    token: 'test-token',
+    diffFiles,
+  };
+
+  const baseConfig: Config = {
+    version: 1,
+    trusted_only: true,
+    triggers: { on: ['pull_request'], branches: ['main'] },
+    passes: [{ name: 'static', agents: ['semgrep'], enabled: true, required: true }],
+    limits: {
+      max_files: 50,
+      max_diff_lines: 2000,
+      max_tokens_per_pr: 12000,
+      max_usd_per_pr: 1.0,
+      monthly_budget_usd: 100,
+    },
+    models: { default: 'gpt-4o-mini' },
+    reporting: {
+      github: {
+        mode: 'checks_and_comments',
+        max_inline_comments: 20,
+        summary: true,
+      },
+    },
+    gating: { enabled: false, fail_on_severity: 'error' },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockChecksCreate.mockResolvedValue({ data: { id: 12345 } });
+    mockChecksUpdate.mockResolvedValue({ data: { id: 12345 } });
+    mockIssuesListComments.mockResolvedValue({ data: [] });
+    mockIssuesCreateComment.mockResolvedValue({ data: { id: 1 } });
+    mockPullsListReviewComments.mockResolvedValue({ data: [] });
+    mockPullsCreateReviewComment.mockResolvedValue({ data: { id: 1 } });
+  });
+
+  describe('Valid line numbers', () => {
+    it('should post comment on valid added line', async () => {
+      const findings: Finding[] = [
+        {
+          severity: 'warning',
+          file: 'src/utils.ts',
+          line: 12, // Line 12 is an added line (const c = 4)
+          message: 'Consider using const instead of let',
+          sourceAgent: 'test-agent',
+        },
+      ];
+
+      const result = await reportToGitHub(findings, baseContext, baseConfig);
+
+      expect(result.success).toBe(true);
+      expect(result.skippedInvalidLines).toBe(0);
+      expect(mockPullsCreateReviewComment).toHaveBeenCalledTimes(1);
+      expect(mockPullsCreateReviewComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: 'src/utils.ts',
+          line: 12,
+        })
+      );
+    });
+
+    it('should post comment on valid context line', async () => {
+      const findings: Finding[] = [
+        {
+          severity: 'info',
+          file: 'src/utils.ts',
+          line: 10, // Line 10 is a context line (const a = 1)
+          message: 'Variable name could be more descriptive',
+          sourceAgent: 'test-agent',
+        },
+      ];
+
+      const result = await reportToGitHub(findings, baseContext, baseConfig);
+
+      expect(result.success).toBe(true);
+      expect(result.skippedInvalidLines).toBe(0);
+      expect(mockPullsCreateReviewComment).toHaveBeenCalledTimes(1);
+    });
+
+    it('should post comments on new file lines', async () => {
+      const findings: Finding[] = [
+        {
+          severity: 'warning',
+          file: 'src/new-file.ts',
+          line: 2, // Line 2: const x = 1
+          message: 'Consider using meaningful variable name',
+          sourceAgent: 'test-agent',
+        },
+      ];
+
+      const result = await reportToGitHub(findings, baseContext, baseConfig);
+
+      expect(result.success).toBe(true);
+      expect(result.skippedInvalidLines).toBe(0);
+      expect(mockPullsCreateReviewComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: 'src/new-file.ts',
+          line: 2,
+        })
+      );
+    });
+  });
+
+  describe('Invalid line numbers', () => {
+    it('should skip comment on line not in diff', async () => {
+      const findings: Finding[] = [
+        {
+          severity: 'error',
+          file: 'src/utils.ts',
+          line: 100, // Line 100 is not in the diff hunks
+          message: 'Security issue found',
+          sourceAgent: 'test-agent',
+        },
+      ];
+
+      const result = await reportToGitHub(findings, baseContext, baseConfig);
+
+      expect(result.success).toBe(true);
+      expect(result.skippedInvalidLines).toBe(1);
+      expect(result.invalidLineDetails).toHaveLength(1);
+      expect(result.invalidLineDetails?.[0]).toMatchObject({
+        file: 'src/utils.ts',
+        line: 100,
+      });
+      expect(result.invalidLineDetails?.[0]?.nearestValidLine).toBeDefined();
+      expect(mockPullsCreateReviewComment).not.toHaveBeenCalled();
+    });
+
+    it('should skip comment on file not in diff', async () => {
+      const findings: Finding[] = [
+        {
+          severity: 'warning',
+          file: 'src/other-file.ts', // This file is not in the diff
+          line: 10,
+          message: 'Issue found',
+          sourceAgent: 'test-agent',
+        },
+      ];
+
+      const result = await reportToGitHub(findings, baseContext, baseConfig);
+
+      expect(result.success).toBe(true);
+      expect(result.skippedInvalidLines).toBe(1);
+      expect(result.invalidLineDetails?.[0]?.reason).toContain('not found in diff');
+      expect(mockPullsCreateReviewComment).not.toHaveBeenCalled();
+    });
+
+    it('should post valid comments and skip invalid ones in mixed batch', async () => {
+      const findings: Finding[] = [
+        {
+          severity: 'error',
+          file: 'src/utils.ts',
+          line: 11, // Valid - added line
+          message: 'Valid issue',
+          sourceAgent: 'test-agent',
+        },
+        {
+          severity: 'warning',
+          file: 'src/utils.ts',
+          line: 50, // Invalid - not in diff
+          message: 'Invalid issue',
+          sourceAgent: 'test-agent',
+        },
+        {
+          severity: 'info',
+          file: 'src/new-file.ts',
+          line: 3, // Valid - added line
+          message: 'Another valid issue',
+          sourceAgent: 'test-agent',
+        },
+      ];
+
+      const result = await reportToGitHub(findings, baseContext, baseConfig);
+
+      expect(result.success).toBe(true);
+      expect(result.skippedInvalidLines).toBe(1);
+      expect(mockPullsCreateReviewComment).toHaveBeenCalledTimes(2);
+    });
+
+    it('should provide nearest valid line suggestion', async () => {
+      const findings: Finding[] = [
+        {
+          severity: 'warning',
+          file: 'src/utils.ts',
+          line: 8, // Line 8 is not in diff, nearest should be 10
+          message: 'Issue found',
+          sourceAgent: 'test-agent',
+        },
+      ];
+
+      const result = await reportToGitHub(findings, baseContext, baseConfig);
+
+      expect(result.skippedInvalidLines).toBe(1);
+      expect(result.invalidLineDetails?.[0]?.nearestValidLine).toBe(10);
+    });
+  });
+
+  describe('Without diff files (backward compatibility)', () => {
+    it('should allow posting when no diffFiles provided', async () => {
+      const contextWithoutDiff: GitHubContext = {
+        owner: 'test-owner',
+        repo: 'test-repo',
+        prNumber: 123,
+        headSha: 'abc123',
+        token: 'test-token',
+        // No diffFiles - validation should be skipped
+      };
+
+      const findings: Finding[] = [
+        {
+          severity: 'warning',
+          file: 'src/utils.ts',
+          line: 100, // Would be invalid if diffFiles were provided
+          message: 'Issue found',
+          sourceAgent: 'test-agent',
+        },
+      ];
+
+      const result = await reportToGitHub(findings, contextWithoutDiff, baseConfig);
+
+      expect(result.success).toBe(true);
+      expect(result.skippedInvalidLines).toBe(0);
+      // Comment should be attempted (may fail at API level but that's separate)
+      expect(mockPullsCreateReviewComment).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('ADO Reporter Line Validation', () => {
+  const diffFiles: DiffFile[] = [
+    {
+      path: 'src/service.ts',
+      status: 'modified',
+      additions: 2,
+      deletions: 1,
+      patch: `@@ -20,3 +20,4 @@ class Service {
+   async init() {
+-    this.configure();
++    await this.configure();
++    this.ready = true;
+   }`,
+    },
+  ];
+
+  const baseContext: ADOContext = {
+    organization: 'test-org',
+    project: 'test-project',
+    repositoryId: 'test-repo',
+    pullRequestId: 456,
+    sourceRefCommit: 'def789',
+    token: 'test-token',
+    diffFiles,
+  };
+
+  const baseConfig: Config = {
+    version: 1,
+    trusted_only: true,
+    triggers: { on: ['pull_request'], branches: ['main'] },
+    passes: [{ name: 'static', agents: ['semgrep'], enabled: true, required: true }],
+    limits: {
+      max_files: 50,
+      max_diff_lines: 2000,
+      max_tokens_per_pr: 12000,
+      max_usd_per_pr: 1.0,
+      monthly_budget_usd: 100,
+    },
+    models: { default: 'gpt-4o-mini' },
+    reporting: {
+      ado: {
+        mode: 'threads_and_status',
+        max_inline_comments: 20,
+        summary: true,
+        thread_status: 'active',
+      },
+    },
+    gating: { enabled: false, fail_on_severity: 'error' },
+  };
+
+  // Mock fetch for ADO API
+  const mockFetch = vi.fn();
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = mockFetch;
+
+    // Default mock responses
+    mockFetch.mockImplementation((url: string, options: RequestInit) => {
+      const urlStr = url.toString();
+
+      // Get threads (for deduplication check)
+      if (urlStr.includes('/threads') && options.method !== 'POST') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ value: [] }),
+        });
+      }
+
+      // Create thread (summary or inline)
+      if (urlStr.includes('/threads') && options.method === 'POST') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ id: 999 }),
+        });
+      }
+
+      // Create commit status
+      if (urlStr.includes('/statuses')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ id: 888 }),
+        });
+      }
+
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe('Valid line numbers', () => {
+    it('should post thread on valid line', async () => {
+      const findings: Finding[] = [
+        {
+          severity: 'warning',
+          file: 'src/service.ts',
+          line: 22, // await this.configure() - added line
+          message: 'Consider error handling for async call',
+          sourceAgent: 'test-agent',
+        },
+      ];
+
+      const result = await reportToADO(findings, baseContext, baseConfig);
+
+      expect(result.success).toBe(true);
+      expect(result.skippedInvalidLines).toBe(0);
+
+      // Check that inline thread was created
+      const inlineThreadCalls = mockFetch.mock.calls.filter(
+        (call) =>
+          call[0].toString().includes('/threads') &&
+          call[1]?.method === 'POST' &&
+          call[1]?.body?.includes('threadContext')
+      );
+      expect(inlineThreadCalls.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Invalid line numbers', () => {
+    it('should skip thread on line not in diff', async () => {
+      const findings: Finding[] = [
+        {
+          severity: 'error',
+          file: 'src/service.ts',
+          line: 5, // Not in the diff hunk (which is around line 20)
+          message: 'Security issue',
+          sourceAgent: 'test-agent',
+        },
+      ];
+
+      const result = await reportToADO(findings, baseContext, baseConfig);
+
+      expect(result.success).toBe(true);
+      expect(result.skippedInvalidLines).toBe(1);
+      expect(result.invalidLineDetails).toHaveLength(1);
+      expect(result.invalidLineDetails?.[0]?.nearestValidLine).toBeDefined();
+    });
+
+    it('should report accurate counts for mixed valid/invalid findings', async () => {
+      const findings: Finding[] = [
+        {
+          severity: 'error',
+          file: 'src/service.ts',
+          line: 21, // Valid - context line
+          message: 'Valid finding 1',
+          sourceAgent: 'test-agent',
+        },
+        {
+          severity: 'warning',
+          file: 'src/service.ts',
+          line: 1, // Invalid - not in diff
+          message: 'Invalid finding',
+          sourceAgent: 'test-agent',
+        },
+        {
+          severity: 'info',
+          file: 'src/service.ts',
+          line: 23, // Valid - this.ready = true added line
+          message: 'Valid finding 2',
+          sourceAgent: 'test-agent',
+        },
+      ];
+
+      const result = await reportToADO(findings, baseContext, baseConfig);
+
+      expect(result.success).toBe(true);
+      expect(result.skippedInvalidLines).toBe(1);
+      expect(result.invalidLineDetails).toHaveLength(1);
+    });
+  });
+
+  describe('Without diff files (backward compatibility)', () => {
+    it('should allow posting when no diffFiles provided', async () => {
+      const contextWithoutDiff: ADOContext = {
+        organization: 'test-org',
+        project: 'test-project',
+        repositoryId: 'test-repo',
+        pullRequestId: 456,
+        sourceRefCommit: 'def789',
+        token: 'test-token',
+        // No diffFiles
+      };
+
+      const findings: Finding[] = [
+        {
+          severity: 'warning',
+          file: 'src/service.ts',
+          line: 100,
+          message: 'Issue found',
+          sourceAgent: 'test-agent',
+        },
+      ];
+
+      const result = await reportToADO(findings, contextWithoutDiff, baseConfig);
+
+      expect(result.success).toBe(true);
+      expect(result.skippedInvalidLines).toBe(0);
+    });
+  });
+});
+
+describe('Edge cases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockChecksCreate.mockResolvedValue({ data: { id: 12345 } });
+    mockChecksUpdate.mockResolvedValue({ data: { id: 12345 } });
+    mockIssuesListComments.mockResolvedValue({ data: [] });
+    mockIssuesCreateComment.mockResolvedValue({ data: { id: 1 } });
+    mockPullsListReviewComments.mockResolvedValue({ data: [] });
+    mockPullsCreateReviewComment.mockResolvedValue({ data: { id: 1 } });
+  });
+
+  const baseConfig: Config = {
+    version: 1,
+    trusted_only: true,
+    triggers: { on: ['pull_request'], branches: ['main'] },
+    passes: [{ name: 'static', agents: ['semgrep'], enabled: true, required: true }],
+    limits: {
+      max_files: 50,
+      max_diff_lines: 2000,
+      max_tokens_per_pr: 12000,
+      max_usd_per_pr: 1.0,
+      monthly_budget_usd: 100,
+    },
+    models: { default: 'gpt-4o-mini' },
+    reporting: {
+      github: {
+        mode: 'checks_and_comments',
+        max_inline_comments: 20,
+        summary: true,
+      },
+    },
+    gating: { enabled: false, fail_on_severity: 'error' },
+  };
+
+  it('should handle findings without line numbers', async () => {
+    const diffFiles: DiffFile[] = [
+      {
+        path: 'src/app.ts',
+        status: 'modified',
+        additions: 1,
+        deletions: 0,
+        patch: `@@ -1,2 +1,3 @@
+ line1
++line2
+ line3`,
+      },
+    ];
+
+    const context: GitHubContext = {
+      owner: 'test-owner',
+      repo: 'test-repo',
+      prNumber: 123,
+      headSha: 'abc123',
+      token: 'test-token',
+      diffFiles,
+    };
+
+    const findings: Finding[] = [
+      {
+        severity: 'warning',
+        file: 'src/app.ts',
+        // No line number - file-level finding
+        message: 'File-level issue',
+        sourceAgent: 'test-agent',
+      },
+    ];
+
+    const result = await reportToGitHub(findings, context, baseConfig);
+
+    expect(result.success).toBe(true);
+    // Findings without line numbers are excluded from inline comments
+    // but should not be counted as invalid lines
+    expect(result.skippedInvalidLines).toBe(0);
+  });
+
+  it('should handle empty diff', async () => {
+    const context: GitHubContext = {
+      owner: 'test-owner',
+      repo: 'test-repo',
+      prNumber: 123,
+      headSha: 'abc123',
+      token: 'test-token',
+      diffFiles: [], // Empty diff
+    };
+
+    const findings: Finding[] = [
+      {
+        severity: 'warning',
+        file: 'src/any-file.ts',
+        line: 10,
+        message: 'Issue found',
+        sourceAgent: 'test-agent',
+      },
+    ];
+
+    const result = await reportToGitHub(findings, context, baseConfig);
+
+    expect(result.success).toBe(true);
+    expect(result.skippedInvalidLines).toBe(1);
+    expect(result.invalidLineDetails?.[0]?.reason).toContain('not found in diff');
+  });
+
+  it('should handle deleted files correctly', async () => {
+    const diffFiles: DiffFile[] = [
+      {
+        path: 'src/deleted.ts',
+        status: 'deleted',
+        additions: 0,
+        deletions: 10,
+        patch: `@@ -1,10 +0,0 @@
+-// All lines deleted`,
+      },
+    ];
+
+    const context: GitHubContext = {
+      owner: 'test-owner',
+      repo: 'test-repo',
+      prNumber: 123,
+      headSha: 'abc123',
+      token: 'test-token',
+      diffFiles,
+    };
+
+    const findings: Finding[] = [
+      {
+        severity: 'info',
+        file: 'src/deleted.ts',
+        line: 1,
+        message: 'Issue in deleted file',
+        sourceAgent: 'test-agent',
+      },
+    ];
+
+    const result = await reportToGitHub(findings, context, baseConfig);
+
+    expect(result.success).toBe(true);
+    // Deleted files have no commentable lines in new version
+    expect(result.skippedInvalidLines).toBe(1);
+  });
+});

--- a/router/src/diff_line_validator.ts
+++ b/router/src/diff_line_validator.ts
@@ -1,0 +1,435 @@
+/**
+ * Diff Line Validator Module
+ * Parses unified diffs to extract valid commentable line ranges
+ *
+ * This module solves the "wrong line" bug by:
+ * 1. Parsing unified diff hunks to extract which lines are actually in the diff
+ * 2. Providing validation to ensure findings only target commentable lines
+ * 3. Offering nearest-line suggestions when a line is out of range
+ *
+ * GitHub and Azure DevOps APIs require inline comments to target lines
+ * that are part of the diff context. Comments on other lines will either
+ * fail silently or appear on unexpected lines.
+ */
+
+import type { DiffFile } from './diff.js';
+
+/**
+ * Represents a single hunk in a unified diff
+ *
+ * A hunk header looks like: @@ -10,5 +15,8 @@
+ * - oldStart: 10 (line number in original file)
+ * - oldCount: 5 (number of lines from original)
+ * - newStart: 15 (line number in new file)
+ * - newCount: 8 (number of lines in new file)
+ */
+export interface DiffHunk {
+  /** Starting line number in the old (base) file */
+  oldStart: number;
+  /** Number of lines from the old file */
+  oldCount: number;
+  /** Starting line number in the new (head) file */
+  newStart: number;
+  /** Number of lines in the new file */
+  newCount: number;
+  /** Lines included in this hunk (context + additions) in the new file */
+  newFileLines: number[];
+  /** Lines that were added ('+' lines) - subset of newFileLines */
+  addedLines: number[];
+  /** Lines that are context (' ' lines) - subset of newFileLines */
+  contextLines: number[];
+}
+
+/**
+ * Map of file paths to their valid commentable lines
+ */
+export interface DiffLineMap {
+  /** Map of file path -> array of valid line numbers in the new file */
+  files: Map<string, DiffFileLines>;
+}
+
+/**
+ * Valid lines for a single file
+ */
+export interface DiffFileLines {
+  /** All lines that appear in the diff (context + additions) */
+  allLines: Set<number>;
+  /** Only lines that were added ('+' lines) */
+  addedLines: Set<number>;
+  /** Only context lines (' ' lines) */
+  contextLines: Set<number>;
+  /** Parsed hunks for detailed analysis */
+  hunks: DiffHunk[];
+}
+
+/**
+ * Result of line validation
+ */
+export interface LineValidationResult {
+  /** Whether the line is valid for commenting */
+  valid: boolean;
+  /** The validated line number (same as input if valid) */
+  line: number;
+  /** If invalid, the nearest valid line (if any) */
+  nearestValidLine?: number;
+  /** Human-readable reason if invalid */
+  reason?: string;
+  /** Whether the line is an addition ('+') vs context */
+  isAddition?: boolean;
+}
+
+/**
+ * Regular expression to parse unified diff hunk headers
+ * Matches: @@ -oldStart,oldCount +newStart,newCount @@
+ * Also handles single-line hunks: @@ -10 +15 @@ (count defaults to 1)
+ */
+const HUNK_HEADER_REGEX = /^@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s+@@/;
+
+/**
+ * Parse a unified diff patch to extract hunk information
+ *
+ * @param patch - The unified diff patch content
+ * @returns Array of parsed hunks
+ */
+export function parseDiffHunks(patch: string): DiffHunk[] {
+  if (!patch) return [];
+
+  const lines = patch.split('\n');
+  const hunks: DiffHunk[] = [];
+
+  let currentHunk: DiffHunk | null = null;
+  let currentNewLine = 0;
+
+  for (const line of lines) {
+    // Check for hunk header
+    const headerMatch = line.match(HUNK_HEADER_REGEX);
+
+    if (headerMatch) {
+      // Save previous hunk if exists
+      if (currentHunk) {
+        hunks.push(currentHunk);
+      }
+
+      // Parse hunk header
+      const oldStart = parseInt(headerMatch[1] ?? '1', 10);
+      const oldCount = parseInt(headerMatch[2] ?? '1', 10);
+      const newStart = parseInt(headerMatch[3] ?? '1', 10);
+      const newCount = parseInt(headerMatch[4] ?? '1', 10);
+
+      currentHunk = {
+        oldStart,
+        oldCount,
+        newStart,
+        newCount,
+        newFileLines: [],
+        addedLines: [],
+        contextLines: [],
+      };
+
+      currentNewLine = newStart;
+      continue;
+    }
+
+    // Process diff lines within a hunk
+    if (currentHunk && line.length > 0) {
+      const prefix = line[0];
+
+      if (prefix === '+') {
+        // Added line - exists in new file
+        currentHunk.newFileLines.push(currentNewLine);
+        currentHunk.addedLines.push(currentNewLine);
+        currentNewLine++;
+      } else if (prefix === '-') {
+        // Deleted line - does NOT exist in new file, don't increment
+        // These lines are only in the old file
+      } else if (prefix === ' ' || prefix === '\\') {
+        // Context line or "\ No newline at end of file"
+        if (prefix === ' ') {
+          currentHunk.newFileLines.push(currentNewLine);
+          currentHunk.contextLines.push(currentNewLine);
+          currentNewLine++;
+        }
+        // '\\' is a git comment, doesn't count as a line
+      }
+      // Lines starting with 'diff', 'index', '---', '+++' are metadata, skip
+    }
+  }
+
+  // Don't forget the last hunk
+  if (currentHunk) {
+    hunks.push(currentHunk);
+  }
+
+  return hunks;
+}
+
+/**
+ * Build a DiffLineMap from an array of DiffFiles
+ *
+ * @param files - Array of DiffFile objects with patches
+ * @returns DiffLineMap with valid lines for each file
+ */
+export function buildDiffLineMap(files: DiffFile[]): DiffLineMap {
+  const map: DiffLineMap = {
+    files: new Map(),
+  };
+
+  for (const file of files) {
+    if (!file.patch || file.status === 'deleted') {
+      // Deleted files have no lines to comment on in the new version
+      continue;
+    }
+
+    const hunks = parseDiffHunks(file.patch);
+    const allLines = new Set<number>();
+    const addedLines = new Set<number>();
+    const contextLines = new Set<number>();
+
+    for (const hunk of hunks) {
+      for (const line of hunk.newFileLines) {
+        allLines.add(line);
+      }
+      for (const line of hunk.addedLines) {
+        addedLines.add(line);
+      }
+      for (const line of hunk.contextLines) {
+        contextLines.add(line);
+      }
+    }
+
+    map.files.set(file.path, {
+      allLines,
+      addedLines,
+      contextLines,
+      hunks,
+    });
+  }
+
+  return map;
+}
+
+/**
+ * Find the nearest valid line to the target line
+ *
+ * @param targetLine - The target line number
+ * @param validLines - Set of valid line numbers
+ * @returns The nearest valid line, or undefined if no valid lines exist
+ */
+export function findNearestValidLine(
+  targetLine: number,
+  validLines: Set<number>
+): number | undefined {
+  if (validLines.size === 0) return undefined;
+  if (validLines.has(targetLine)) return targetLine;
+
+  const sortedLines = Array.from(validLines).sort((a, b) => a - b);
+
+  let nearest: number | undefined;
+  let minDistance = Infinity;
+
+  for (const line of sortedLines) {
+    const distance = Math.abs(line - targetLine);
+    if (distance < minDistance) {
+      minDistance = distance;
+      nearest = line;
+    }
+    // Early exit if we've passed the target (lines are sorted)
+    if (line > targetLine && distance > minDistance) {
+      break;
+    }
+  }
+
+  return nearest;
+}
+
+/**
+ * Validate if a line number is valid for commenting on a specific file
+ *
+ * @param filePath - The file path to validate against
+ * @param line - The line number to validate
+ * @param diffLineMap - The DiffLineMap built from the PR diff
+ * @param options - Validation options
+ * @returns LineValidationResult with validity and suggestions
+ */
+export function validateFindingLine(
+  filePath: string,
+  line: number | undefined,
+  diffLineMap: DiffLineMap,
+  options: {
+    /** If true, only allow additions ('+' lines), not context */
+    additionsOnly?: boolean;
+    /** If true, find and return nearest valid line when invalid */
+    suggestNearest?: boolean;
+  } = {}
+): LineValidationResult {
+  // Handle undefined line
+  if (line === undefined) {
+    return {
+      valid: false,
+      line: 0,
+      reason: 'Line number is undefined',
+    };
+  }
+
+  // Handle non-positive line numbers
+  if (line <= 0) {
+    return {
+      valid: false,
+      line,
+      reason: `Invalid line number: ${line} (must be positive)`,
+    };
+  }
+
+  // Get file lines from map
+  const fileLines = diffLineMap.files.get(filePath);
+
+  if (!fileLines) {
+    return {
+      valid: false,
+      line,
+      reason: `File "${filePath}" not found in diff or has no commentable lines`,
+    };
+  }
+
+  // Determine which line set to check
+  const validLines = options.additionsOnly ? fileLines.addedLines : fileLines.allLines;
+
+  if (validLines.has(line)) {
+    return {
+      valid: true,
+      line,
+      isAddition: fileLines.addedLines.has(line),
+    };
+  }
+
+  // Line is not valid
+  const result: LineValidationResult = {
+    valid: false,
+    line,
+    reason: options.additionsOnly
+      ? `Line ${line} is not an added line in the diff`
+      : `Line ${line} is not in the diff context for file "${filePath}"`,
+  };
+
+  // Find nearest valid line if requested
+  if (options.suggestNearest) {
+    const nearest = findNearestValidLine(line, validLines);
+    if (nearest !== undefined) {
+      result.nearestValidLine = nearest;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Filter findings to only those with valid line numbers
+ *
+ * @param findings - Array of findings to filter
+ * @param diffLineMap - The DiffLineMap built from the PR diff
+ * @param options - Filtering options
+ * @returns Object with valid findings, invalid findings, and validation details
+ */
+export function filterValidFindings<T extends { file: string; line?: number }>(
+  findings: T[],
+  diffLineMap: DiffLineMap,
+  options: {
+    /** If true, only allow additions ('+' lines), not context */
+    additionsOnly?: boolean;
+    /** If true, attempt to fix invalid lines by using nearest valid line */
+    autoFixLines?: boolean;
+  } = {}
+): {
+  valid: T[];
+  invalid: { finding: T; reason: string; nearestValidLine?: number }[];
+  stats: {
+    total: number;
+    valid: number;
+    invalid: number;
+    autoFixed: number;
+  };
+} {
+  const valid: T[] = [];
+  const invalid: { finding: T; reason: string; nearestValidLine?: number }[] = [];
+  let autoFixed = 0;
+
+  for (const finding of findings) {
+    const validation = validateFindingLine(finding.file, finding.line, diffLineMap, {
+      additionsOnly: options.additionsOnly,
+      suggestNearest: options.autoFixLines,
+    });
+
+    if (validation.valid) {
+      valid.push(finding);
+    } else if (options.autoFixLines && validation.nearestValidLine !== undefined) {
+      // Auto-fix by using nearest valid line
+      const fixed = { ...finding, line: validation.nearestValidLine };
+      valid.push(fixed);
+      autoFixed++;
+    } else {
+      invalid.push({
+        finding,
+        reason: validation.reason ?? 'Unknown validation error',
+        nearestValidLine: validation.nearestValidLine,
+      });
+    }
+  }
+
+  return {
+    valid,
+    invalid,
+    stats: {
+      total: findings.length,
+      valid: valid.length - autoFixed,
+      invalid: invalid.length,
+      autoFixed,
+    },
+  };
+}
+
+/**
+ * Get a summary of valid lines for a file (useful for debugging)
+ */
+export function getFileDiffSummary(filePath: string, diffLineMap: DiffLineMap): string {
+  const fileLines = diffLineMap.files.get(filePath);
+
+  if (!fileLines) {
+    return `File "${filePath}" not in diff`;
+  }
+
+  const allLinesSorted = Array.from(fileLines.allLines).sort((a, b) => a - b);
+  const addedLinesSorted = Array.from(fileLines.addedLines).sort((a, b) => a - b);
+
+  // Compress ranges for display (e.g., [1,2,3,5,6,7] -> "1-3, 5-7")
+  const compressRanges = (lines: number[]): string => {
+    if (lines.length === 0) return 'none';
+
+    const ranges: string[] = [];
+    const firstLine = lines[0];
+    if (firstLine === undefined) return 'none';
+    let start = firstLine;
+    let end = start;
+
+    for (let i = 1; i <= lines.length; i++) {
+      const current = lines[i];
+      if (current === end + 1) {
+        end = current;
+      } else {
+        ranges.push(start === end ? `${start}` : `${start}-${end}`);
+        if (current !== undefined) {
+          start = current;
+          end = current;
+        }
+      }
+    }
+
+    return ranges.join(', ');
+  };
+
+  return [
+    `File: ${filePath}`,
+    `  All valid lines: ${compressRanges(allLinesSorted)}`,
+    `  Added lines: ${compressRanges(addedLinesSorted)}`,
+    `  Hunks: ${fileLines.hunks.length}`,
+  ].join('\n');
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive diff line validation to prevent posting inline comments on lines that don't exist in the pull request diff. When findings reference lines outside the diff context, they are now skipped with detailed reporting of why they were invalid and suggestions for the nearest valid line.

## Key Changes

- **New `diff_line_validator` module** (`router/src/diff_line_validator.ts`):
  - `parseDiffHunks()`: Parses unified diff format to extract valid line ranges per hunk
  - `buildDiffLineMap()`: Creates a map of all valid lines (added and context) for each file in the diff
  - `validateFindingLine()`: Validates individual finding line numbers against the diff with optional auto-fix suggestions
  - `filterValidFindings()`: Batch validates findings and separates valid from invalid with statistics
  - `findNearestValidLine()`: Suggests the closest valid line when a finding references an invalid line
  - `getFileDiffSummary()`: Generates human-readable summaries of diff coverage per file

- **Comprehensive test coverage** (`router/src/__tests__/diff_line_validator.test.ts`):
  - 604 lines of tests covering all parsing scenarios (additions, deletions, context lines, multiple hunks, edge cases)
  - Real-world diff scenarios including multi-hunk TypeScript files, renamed files, and large gaps between hunks
  - Tests for all validation functions with various input combinations

- **Reporter integration tests** (`router/src/__tests__/reporter_line_validation.test.ts`):
  - 654 lines of tests verifying GitHub and ADO reporters validate lines before posting
  - Tests for valid/invalid line handling, mixed batches, and backward compatibility
  - Edge case coverage (findings without line numbers, empty diffs, deleted files)

## Implementation Details

- **Diff parsing**: Handles unified diff format including edge cases like "No newline at end of file" markers and single-line hunks without explicit counts
- **Line tracking**: Distinguishes between added lines and context lines, enabling optional `additionsOnly` filtering
- **Graceful degradation**: When diff files aren't provided, validation is skipped for backward compatibility
- **Detailed reporting**: Invalid findings include the reason for rejection and nearest valid line suggestion for user guidance
- **Performance**: Uses Set-based lookups for O(1) line validation after initial parsing

## Testing
- 1,258 lines of test code across two test files
- Covers parsing, validation, filtering, and reporter integration
- Tests both happy paths and edge cases