### PR TITLE
fix: resolve inline comment line mapping for GitHub and ADO

### DIFF
--- a/config/prompts/opencode_system.md
+++ b/config/prompts/opencode_system.md
@@ -20,6 +20,12 @@ For each issue found, provide:
 - **Message**: Clear description of the issue
 - **Suggestion**: Specific fix or improvement (when possible)
 
+## Line Numbering Requirements
+
+- Use **new-file line numbers** computed from the unified diff hunk headers (`@@ -a,b +c,d @@`).
+- Only report line numbers that exist on the **right side** of the diff (added or context lines).
+- If the exact line cannot be determined, omit the line number.
+
 ## Guidelines
 
 - Be specific and actionable

--- a/config/prompts/pr_agent_review.md
+++ b/config/prompts/pr_agent_review.md
@@ -17,3 +17,9 @@ Respond with structured JSON containing:
 - type: string
 - findings: array of { severity, file, line, message, suggestion }
 - overall_assessment: string (approve, comment, request_changes)
+
+## Line Numbering Requirements
+
+- Use **new-file line numbers** derived from the unified diff hunk headers (`@@ -a,b +c,d @@`).
+- Only report line numbers that exist in the **right side** of the diff (added or context lines).
+- If you cannot determine a precise line number, omit the `line` field.

--- a/router/src/__tests__/check_run_lifecycle.test.ts
+++ b/router/src/__tests__/check_run_lifecycle.test.ts
@@ -120,7 +120,7 @@ describe('Check Run Lifecycle', () => {
         checkRunId: 12345,
       };
 
-      await reportToGitHub([], contextWithCheckRun, baseConfig);
+      await reportToGitHub([], contextWithCheckRun, baseConfig, []);
 
       // Should call update, not create for the check run
       expect(mockChecksUpdate).toHaveBeenCalled();
@@ -139,7 +139,7 @@ describe('Check Run Lifecycle', () => {
         checkRunId: 12345,
       };
 
-      await reportToGitHub([], contextWithCheckRun, baseConfig);
+      await reportToGitHub([], contextWithCheckRun, baseConfig, []);
 
       expect(mockChecksUpdate).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -154,7 +154,7 @@ describe('Check Run Lifecycle', () => {
         checkRunId: 12345,
       };
 
-      const result = await reportToGitHub([], contextWithCheckRun, baseConfig);
+      const result = await reportToGitHub([], contextWithCheckRun, baseConfig, []);
 
       expect(result.checkRunId).toBe(12345);
     });
@@ -166,7 +166,7 @@ describe('Check Run Lifecycle', () => {
       mockChecksCreate.mockClear();
       mockChecksUpdate.mockClear();
 
-      await reportToGitHub([], baseContext, baseConfig);
+      await reportToGitHub([], baseContext, baseConfig, []);
 
       // Should call create (for new check run), not update
       expect(mockChecksCreate).toHaveBeenCalled();
@@ -198,7 +198,7 @@ describe('Check Run Lifecycle', () => {
       mockChecksUpdate.mockClear();
 
       // When mode is comments_only, reportToGitHub should skip check run creation
-      await reportToGitHub([], baseContext, commentsOnlyConfig);
+      await reportToGitHub([], baseContext, commentsOnlyConfig, []);
 
       // No check run should be created or updated
       expect(mockChecksCreate).not.toHaveBeenCalled();
@@ -214,7 +214,7 @@ describe('Check Run Lifecycle', () => {
         checkRunId: 12345,
       };
 
-      await reportToGitHub([], contextWithCheckRun, commentsOnlyConfig);
+      await reportToGitHub([], contextWithCheckRun, commentsOnlyConfig, []);
 
       // Even with checkRunId, should not touch checks when mode is comments_only
       expect(mockChecksCreate).not.toHaveBeenCalled();

--- a/router/src/__tests__/github_line_mapping.test.ts
+++ b/router/src/__tests__/github_line_mapping.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Config } from '../config.js';
+import type { DiffFile } from '../diff.js';
+import type { Finding } from '../agents/index.js';
+
+const mockChecksCreate = vi.fn();
+const mockChecksUpdate = vi.fn();
+const mockIssuesListComments = vi.fn();
+const mockCreateReviewComment = vi.fn().mockResolvedValue({ data: { id: 1 } });
+
+vi.mock('@octokit/rest', () => ({
+  Octokit: vi.fn(() => ({
+    checks: {
+      create: mockChecksCreate,
+      update: mockChecksUpdate,
+    },
+    issues: {
+      listComments: mockIssuesListComments,
+      createComment: vi.fn().mockResolvedValue({ data: { id: 1 } }),
+      updateComment: vi.fn().mockResolvedValue({ data: { id: 1 } }),
+    },
+    pulls: {
+      listReviewComments: vi.fn().mockResolvedValue({ data: [] }),
+      createReviewComment: mockCreateReviewComment,
+    },
+  })),
+}));
+
+const { reportToGitHub } = await import('../report/github.js');
+type GitHubContext = Parameters<typeof reportToGitHub>[1];
+
+describe('GitHub line mapping', () => {
+  const baseContext: GitHubContext = {
+    owner: 'test-owner',
+    repo: 'test-repo',
+    prNumber: 123,
+    headSha: 'abc123',
+    token: 'test-token',
+  };
+
+  const baseConfig: Config = {
+    version: 1,
+    trusted_only: true,
+    triggers: { on: ['pull_request'], branches: ['main'] },
+    passes: [{ name: 'static', agents: ['semgrep'], enabled: true, required: true }],
+    limits: {
+      max_files: 50,
+      max_diff_lines: 2000,
+      max_tokens_per_pr: 12000,
+      max_usd_per_pr: 1.0,
+      monthly_budget_usd: 100,
+    },
+    models: { default: 'gpt-4o-mini' },
+    reporting: {
+      github: {
+        mode: 'comments_only',
+        max_inline_comments: 20,
+        summary: true,
+      },
+    },
+    gating: { enabled: false, fail_on_severity: 'error' },
+  };
+
+  const diffFiles: DiffFile[] = [
+    {
+      path: 'src/test.ts',
+      status: 'modified',
+      additions: 2,
+      deletions: 1,
+      patch: [
+        'diff --git a/src/test.ts b/src/test.ts',
+        'index 1234567..89abcde 100644',
+        '--- a/src/test.ts',
+        '+++ b/src/test.ts',
+        '@@ -1,3 +1,4 @@',
+        '-const a = 1;',
+        '+const a = 1;',
+        '+const b = 2;',
+        ' const c = 3;',
+      ].join('\n'),
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockChecksCreate.mockResolvedValue({ data: { id: 123 } });
+    mockChecksUpdate.mockResolvedValue({ data: { id: 123 } });
+    mockIssuesListComments.mockResolvedValue({ data: [] });
+  });
+
+  it('maps diff line numbers to file line numbers for inline comments', async () => {
+    const findings: Finding[] = [
+      {
+        severity: 'error',
+        file: 'src/test.ts',
+        line: 3,
+        message: 'Mapped line test',
+        sourceAgent: 'pr_agent',
+      },
+    ];
+
+    await reportToGitHub(findings, baseContext, baseConfig, diffFiles);
+
+    expect(mockCreateReviewComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        line: 2,
+        path: 'src/test.ts',
+      })
+    );
+  });
+});

--- a/router/src/__tests__/line_mapping.test.ts
+++ b/router/src/__tests__/line_mapping.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import type { DiffFile } from '../diff.js';
+import type { Finding } from '../agents/index.js';
+import { buildLineResolver, normalizeFindingsForDiff } from '../report/line-mapping.js';
+
+describe('Line mapping', () => {
+  const patch = [
+    'diff --git a/src/test.ts b/src/test.ts',
+    'index 1234567..89abcde 100644',
+    '--- a/src/test.ts',
+    '+++ b/src/test.ts',
+    '@@ -1,3 +1,4 @@',
+    '-const a = 1;',
+    '+const a = 1;',
+    '+const b = 2;',
+    ' const c = 3;',
+  ].join('\n');
+
+  const diffFiles: DiffFile[] = [
+    {
+      path: 'src/test.ts',
+      status: 'modified',
+      additions: 2,
+      deletions: 1,
+      patch,
+    },
+  ];
+
+  it('resolves file line numbers directly when present in diff', () => {
+    const resolver = buildLineResolver(diffFiles);
+    expect(resolver.resolveLine('src/test.ts', 2, 'semgrep')).toBe(2);
+  });
+
+  it('resolves diff line numbers to file line numbers', () => {
+    const resolver = buildLineResolver(diffFiles);
+    expect(resolver.resolveLine('src/test.ts', 3, 'pr_agent')).toBe(2);
+  });
+
+  it('drops unresolved lines during normalization', () => {
+    const resolver = buildLineResolver(diffFiles);
+    const findings: Finding[] = [
+      {
+        severity: 'error',
+        file: 'src/test.ts',
+        line: 99,
+        message: 'Out of range',
+        sourceAgent: 'semgrep',
+      },
+    ];
+
+    const normalized = normalizeFindingsForDiff(findings, resolver);
+    expect(normalized[0]?.line).toBeUndefined();
+  });
+});

--- a/router/src/agents/ai_semantic_review.ts
+++ b/router/src/agents/ai_semantic_review.ts
@@ -203,6 +203,10 @@ Analyze the provided diff for:
 - API misuse or anti-patterns
 - Missing error handling
 
+Line numbering requirements:
+- Use new-file line numbers from unified diff hunk headers (@@ -a,b +c,d @@).
+- Only use right-side diff lines (added or context). If unsure, omit the line.
+
 Return a JSON object with findings.`;
 
     if (existsSync(PROMPT_PATH)) {

--- a/router/src/main.ts
+++ b/router/src/main.ts
@@ -459,7 +459,7 @@ async function runReview(options: ReviewOptions): Promise<void> {
       };
 
       console.log('[router] Reporting to GitHub...');
-      const reportResult = await reportToGitHub(sorted, githubContext, config);
+      const reportResult = await reportToGitHub(sorted, githubContext, config, diff.files);
 
       if (reportResult.success) {
         console.log('[router] Successfully reported to GitHub');
@@ -489,7 +489,7 @@ async function runReview(options: ReviewOptions): Promise<void> {
         };
 
         console.log('[router] Reporting to Azure DevOps...');
-        const reportResult = await reportToADO(sorted, adoContext, config);
+        const reportResult = await reportToADO(sorted, adoContext, config, diff.files);
 
         if (reportResult.success) {
           console.log('[router] Successfully reported to Azure DevOps');

--- a/router/src/report/line-mapping.ts
+++ b/router/src/report/line-mapping.ts
@@ -1,0 +1,134 @@
+/**
+ * Line Mapping Utilities
+ * Resolves finding line numbers against unified diffs to prevent misaligned comments.
+ */
+
+import type { DiffFile } from '../diff.js';
+import type { Finding } from '../agents/index.js';
+
+interface FileLineMapping {
+  fileLines: Set<number>;
+  diffLineToFileLine: Map<number, number>;
+}
+
+export interface LineResolver {
+  resolveLine(filePath: string, line: number, sourceAgent?: string): number | null;
+}
+
+function normalizePath(filePath: string): string {
+  return filePath.startsWith('/') ? filePath.slice(1) : filePath;
+}
+
+function parseHunkHeader(line: string): { oldStart: number; newStart: number } | null {
+  const match = line.match(/@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+  if (!match) return null;
+  return { oldStart: parseInt(match[1] ?? '0', 10), newStart: parseInt(match[2] ?? '0', 10) };
+}
+
+function buildFileLineMapping(patch: string): FileLineMapping {
+  const fileLines = new Set<number>();
+  const diffLineToFileLine = new Map<number, number>();
+
+  const lines = patch.split('\n');
+  let newLine = 0;
+  let inHunk = false;
+  let diffLine = 0;
+
+  for (const rawLine of lines) {
+    if (rawLine.startsWith('@@')) {
+      const header = parseHunkHeader(rawLine);
+      if (header) {
+        newLine = header.newStart;
+        inHunk = true;
+      }
+      continue;
+    }
+
+    if (!inHunk) {
+      continue;
+    }
+
+    if (rawLine.startsWith('\\')) {
+      continue;
+    }
+
+    diffLine += 1;
+
+    if (rawLine.startsWith('+') && !rawLine.startsWith('+++')) {
+      fileLines.add(newLine);
+      diffLineToFileLine.set(diffLine, newLine);
+      newLine += 1;
+      continue;
+    }
+
+    if (rawLine.startsWith('-') && !rawLine.startsWith('---')) {
+      continue;
+    }
+
+    fileLines.add(newLine);
+    diffLineToFileLine.set(diffLine, newLine);
+    newLine += 1;
+  }
+
+  return { fileLines, diffLineToFileLine };
+}
+
+function shouldPreferDiffLine(sourceAgent?: string): boolean {
+  if (!sourceAgent) return false;
+  return ['opencode', 'pr_agent', 'ai_semantic_review', 'local_llm'].includes(sourceAgent);
+}
+
+export function buildLineResolver(files: DiffFile[]): LineResolver {
+  const mappings = new Map<string, FileLineMapping>();
+
+  for (const file of files) {
+    if (!file.patch) continue;
+    mappings.set(normalizePath(file.path), buildFileLineMapping(file.patch));
+  }
+
+  return {
+    resolveLine(filePath: string, line: number, sourceAgent?: string): number | null {
+      const mapping = mappings.get(normalizePath(filePath));
+      if (!mapping) return line;
+      const diffCandidate = mapping.diffLineToFileLine.get(line);
+      const hasFileLine = mapping.fileLines.has(line);
+      const preferDiffLine = shouldPreferDiffLine(sourceAgent);
+
+      if (preferDiffLine && diffCandidate) {
+        return diffCandidate;
+      }
+
+      if (hasFileLine) return line;
+      return null;
+    },
+  };
+}
+
+export function normalizeFindingsForDiff(findings: Finding[], resolver: LineResolver): Finding[] {
+  return findings.map((finding) => {
+    if (!finding.line) return finding;
+    const resolvedLine = resolver.resolveLine(finding.file, finding.line, finding.sourceAgent);
+    if (!resolvedLine) {
+      return {
+        ...finding,
+        line: undefined,
+        endLine: undefined,
+      };
+    }
+
+    if (!finding.endLine) {
+      return {
+        ...finding,
+        line: resolvedLine,
+      };
+    }
+
+    const resolvedEndLine =
+      resolver.resolveLine(finding.file, finding.endLine, finding.sourceAgent) ?? resolvedLine;
+    return {
+      ...finding,
+      line: resolvedLine,
+      endLine: resolvedEndLine,
+    };
+  });
+}


### PR DESCRIPTION
### Motivation

- Prevent misaligned inline comments by mapping reported line numbers (from tools and LLMs) against unified diffs so comments use accurate new-file line numbers for both GitHub and Azure DevOps.
- Standardize LLM prompt guidance so agents emit line numbers consistent with diff-derived new-file numbering.

### Description

- Add a diff-aware line resolver in `router/src/report/line-mapping.ts` that builds per-file mappings from unified diffs and exposes `buildLineResolver` and `normalizeFindingsForDiff` to translate or drop invalid line references.
- Normalize findings before reporting by calling `buildLineResolver(...)` and `normalizeFindingsForDiff(...)` in both reporters, and switch the reporters to accept a `diffFiles: DiffFile[]` parameter; updated function signatures: `reportToGitHub(..., diffFiles)` and `reportToADO(..., diffFiles)`.
- Propagate diff context from the router by passing `diff.files` into `reportToGitHub` and `reportToADO` from `router/src/main.ts` so reporters can resolve lines.
- Update prompts and `ai_semantic_review` agent system prompt to require new-file (right-side) diff line numbers when present and instruct omission when uncertain (`config/prompts/*` and `router/src/agents/ai_semantic_review.ts`).
- Add tests covering resolver behavior and integration with reporters: `router/src/__tests__/line_mapping.test.ts`, `router/src/__tests__/github_line_mapping.test.ts`, and an added ADO inline mapping test in `router/src/__tests__/ado.test.ts` and update call sites in existing tests to pass `diffFiles` where required.
- Minor lint/format adjustments to satisfy project checks (Prettier/ESLint) and ensure tests run cleanly.

### Testing

- Ran linter with `npm run lint` and fixed issues; result: passed.
- Ran full unit test suite with `npm run test` and validated all tests passed (including new mapping tests); result: passed.
- Ran focused mapping tests with `npm run test --workspace=router -- --run src/__tests__/line_mapping.test.ts` to validate resolver edge cases; result: passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974ce65787883338f2ff5ebf92c90de)