### PR TITLE
Add .reviewignore support to skip ignored files in review flow

### DIFF
--- a/router/src/__tests__/reviewignore.test.ts
+++ b/router/src/__tests__/reviewignore.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { filterReviewIgnoredFiles, loadReviewIgnore } from '../reviewignore.js';
+import type { DiffFile } from '../diff.js';
+
+describe('reviewignore', () => {
+  it('returns null when .reviewignore is missing', () => {
+    const repoPath = mkdtempSync(join(tmpdir(), 'reviewignore-missing-'));
+    try {
+      expect(loadReviewIgnore(repoPath)).toBeNull();
+    } finally {
+      rmSync(repoPath, { recursive: true, force: true });
+    }
+  });
+
+  it('filters files with standard patterns and negations', () => {
+    const repoPath = mkdtempSync(join(tmpdir(), 'reviewignore-basic-'));
+    const reviewIgnore = `
+# Ignore vendor code
+node_modules/
+dist/**
+!dist/keep.js
+**/*.log
+`;
+    const files: DiffFile[] = [
+      { path: 'src/index.ts', status: 'modified', additions: 1, deletions: 1 },
+      { path: 'node_modules/lib/index.js', status: 'modified', additions: 1, deletions: 1 },
+      { path: 'dist/drop.js', status: 'modified', additions: 1, deletions: 1 },
+      { path: 'dist/keep.js', status: 'modified', additions: 1, deletions: 1 },
+      { path: 'logs/error.log', status: 'modified', additions: 1, deletions: 1 },
+    ];
+
+    try {
+      writeFileSync(join(repoPath, '.reviewignore'), reviewIgnore);
+      const reviewIgnoreConfig = loadReviewIgnore(repoPath);
+      const result = filterReviewIgnoredFiles(files, reviewIgnoreConfig);
+
+      expect(result.filtered.map((file) => file.path)).toEqual(['src/index.ts', 'dist/keep.js']);
+      expect(result.ignored.map((file) => file.path)).toEqual([
+        'node_modules/lib/index.js',
+        'dist/drop.js',
+        'logs/error.log',
+      ]);
+    } finally {
+      rmSync(repoPath, { recursive: true, force: true });
+    }
+  });
+
+  it('respects rooted patterns', () => {
+    const repoPath = mkdtempSync(join(tmpdir(), 'reviewignore-rooted-'));
+    const reviewIgnore = `
+/build
+`;
+    const files: DiffFile[] = [
+      { path: 'build/output.js', status: 'modified', additions: 1, deletions: 1 },
+      { path: 'src/build/output.js', status: 'modified', additions: 1, deletions: 1 },
+    ];
+
+    try {
+      writeFileSync(join(repoPath, '.reviewignore'), reviewIgnore);
+      const reviewIgnoreConfig = loadReviewIgnore(repoPath);
+      const result = filterReviewIgnoredFiles(files, reviewIgnoreConfig);
+
+      expect(result.filtered.map((file) => file.path)).toEqual(['src/build/output.js']);
+      expect(result.ignored.map((file) => file.path)).toEqual(['build/output.js']);
+    } finally {
+      rmSync(repoPath, { recursive: true, force: true });
+    }
+  });
+});

--- a/router/src/reviewignore.ts
+++ b/router/src/reviewignore.ts
@@ -1,0 +1,170 @@
+/**
+ * Review Ignore Utilities
+ *
+ * Supports .reviewignore files with .gitignore-compatible semantics.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { minimatch } from 'minimatch';
+import type { DiffFile } from './diff.js';
+import { normalizePath } from './diff.js';
+import { assertSafeRepoPath } from './git-validators.js';
+
+interface ReviewIgnoreRule {
+  pattern: string;
+  negated: boolean;
+  rooted: boolean;
+  directoryOnly: boolean;
+}
+
+export interface ReviewIgnore {
+  rules: ReviewIgnoreRule[];
+  patterns: string[];
+  sourcePath: string;
+}
+
+export interface ReviewIgnoreFilterResult {
+  filtered: DiffFile[];
+  ignored: DiffFile[];
+}
+
+const REVIEWIGNORE_FILENAME = '.reviewignore';
+
+/**
+ * Load .reviewignore from repository root if present.
+ */
+export function loadReviewIgnore(repoPath: string): ReviewIgnore | null {
+  assertSafeRepoPath(repoPath);
+  const sourcePath = join(repoPath, REVIEWIGNORE_FILENAME);
+  if (!existsSync(sourcePath)) return null;
+
+  const contents = readFileSync(sourcePath, 'utf-8');
+  const parsed = parseReviewIgnore(contents);
+  if (parsed.patterns.length === 0) {
+    return { rules: [], patterns: [], sourcePath };
+  }
+
+  return { rules: parsed.rules, patterns: parsed.patterns, sourcePath };
+}
+
+/**
+ * Apply .reviewignore patterns to diff files.
+ */
+export function filterReviewIgnoredFiles(
+  files: DiffFile[],
+  reviewIgnore: ReviewIgnore | null
+): ReviewIgnoreFilterResult {
+  if (!reviewIgnore) {
+    return { filtered: files, ignored: [] };
+  }
+
+  const ignored: DiffFile[] = [];
+  const filtered = files.filter((file) => {
+    const normalized = normalizePath(file.path);
+    if (shouldIgnorePath(normalized, reviewIgnore.rules)) {
+      ignored.push(file);
+      return false;
+    }
+    return true;
+  });
+
+  return { filtered, ignored };
+}
+
+function parseReviewIgnore(contents: string): { rules: ReviewIgnoreRule[]; patterns: string[] } {
+  const rules: ReviewIgnoreRule[] = [];
+  const patterns: string[] = [];
+
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const parsed = parseReviewIgnoreLine(rawLine);
+    if (!parsed) continue;
+    patterns.push(parsed.original);
+    rules.push(parsed.rule);
+  }
+
+  return { rules, patterns };
+}
+
+function parseReviewIgnoreLine(
+  rawLine: string
+): { original: string; rule: ReviewIgnoreRule } | null {
+  if (!rawLine) return null;
+
+  let line = rawLine;
+  if (line.startsWith('\\#') || line.startsWith('\\!')) {
+    line = line.slice(1);
+  }
+
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith('#')) {
+    return null;
+  }
+
+  let negated = false;
+  let pattern = trimmed;
+  if (pattern.startsWith('!')) {
+    negated = true;
+    pattern = pattern.slice(1);
+  }
+
+  if (!pattern) return null;
+
+  const rooted = pattern.startsWith('/');
+  if (rooted) {
+    pattern = pattern.slice(1);
+  }
+
+  const directoryOnly = pattern.endsWith('/');
+  if (directoryOnly) {
+    pattern = pattern.slice(0, -1);
+  }
+
+  return {
+    original: trimmed,
+    rule: {
+      pattern,
+      negated,
+      rooted,
+      directoryOnly,
+    },
+  };
+}
+
+function shouldIgnorePath(path: string, rules: ReviewIgnoreRule[]): boolean {
+  let ignored = false;
+  for (const rule of rules) {
+    if (!rule.pattern) continue;
+    if (matchesRule(path, rule)) {
+      ignored = !rule.negated;
+    }
+  }
+  return ignored;
+}
+
+function matchesRule(path: string, rule: ReviewIgnoreRule): boolean {
+  const hasSlash = rule.pattern.includes('/');
+  const hasGlob = /[*?[\]]/.test(rule.pattern);
+
+  if (rule.directoryOnly) {
+    const pattern = rule.rooted ? `${rule.pattern}/**` : `**/${rule.pattern}/**`;
+    return minimatch(path, pattern, { dot: true });
+  }
+
+  if (!hasSlash && !hasGlob) {
+    if (rule.rooted) {
+      return path === rule.pattern || path.startsWith(`${rule.pattern}/`);
+    }
+    return path.split('/').includes(rule.pattern);
+  }
+
+  if (rule.rooted) {
+    return minimatch(path, rule.pattern, { dot: true });
+  }
+
+  if (!hasSlash) {
+    return minimatch(path, rule.pattern, { dot: true, matchBase: true });
+  }
+
+  return minimatch(path, `**/${rule.pattern}`, { dot: true });
+}


### PR DESCRIPTION
### Motivation
- Provide a repository-level ignore file (`.reviewignore`) so files like `node_modules` or build artifacts can be completely excluded from AI/code review runs using familiar gitignore-style semantics.
- Ensure ignore handling is applied early in the review pipeline so ignored files never reach agents or count against budgets.

### Description
- Added a new module `router/src/reviewignore.ts` that parses `.reviewignore` and implements matching with gitignore-compatible semantics (supports negation `!`, rooted patterns `/`, directory-only rules, and globs) and uses `minimatch` for pattern matching and `normalizePath` for canonicalization.
- Integrated `.reviewignore` loading and filtering into the review flow in `router/src/main.ts` so files are filtered by `.reviewignore` before applying existing `config.path_filters`.
- Implemented a robust, testable parser that returns parsed rule metadata and applies rules in order so later negations can un-ignore paths as expected.
- Added unit tests at `router/src/__tests__/reviewignore.test.ts` covering missing file behavior, standard patterns with negations, and rooted pattern handling.

### Testing
- Ran lint and formatting checks with `npm run lint` and `npm run format:check` and fixed formatting issues; both passed.
- Ran TypeScript checks with `npm run typecheck`; type checking passed with no errors.
- Ran the full test suite with `npm run test` (router workspace); all tests passed including the new `reviewignore` tests (all test files: 37 passed, tests: 744 passed, 3 skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69784fe98ae08333b1a3e8b947770953)