### PR TITLE
fix: auto-regenerate docs manifest on pre-commit

### DIFF
--- a/docs/viewer/manifest.json
+++ b/docs/viewer/manifest.json
@@ -84,6 +84,11 @@
       "path": "../OSCR-INTEGRATION.md"
     },
     {
+      "name": "REVIEW_TEAM.md",
+      "type": "file",
+      "path": "../REVIEW_TEAM.md"
+    },
+    {
       "name": "ROADMAP.md",
       "type": "file",
       "path": "../ROADMAP.md"
@@ -174,6 +179,11 @@
       "name": "OSCR-INTEGRATION.md",
       "type": "file",
       "path": "../OSCR-INTEGRATION.md"
+    },
+    {
+      "name": "REVIEW_TEAM.md",
+      "type": "file",
+      "path": "../REVIEW_TEAM.md"
     },
     {
       "name": "ROADMAP.md",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "typescript-eslint": "8.54.0"
   },
   "lint-staged": {
+    "docs/**/*.md": [
+      "node scripts/regenerate-docs-manifest.cjs"
+    ],
     "*.{js,cjs,ts,mjs,json,md,yml,yaml}": [
       "prettier --check"
     ],

--- a/scripts/regenerate-docs-manifest.cjs
+++ b/scripts/regenerate-docs-manifest.cjs
@@ -1,0 +1,59 @@
+/**
+ * Regenerate Docs Manifest for Pre-Commit Hook
+ *
+ * Called by lint-staged when markdown files in the docs directory change.
+ * Ensures Local = CI parity (Invariant 33 from INVARIANTS.md).
+ *
+ * This script:
+ * 1. Regenerates the docs manifest using generate-docs-manifest.cjs
+ * 2. Detects if the manifest changed
+ * 3. Auto-stages the manifest for the current commit
+ *
+ * Usage: Called automatically by lint-staged, not for direct invocation.
+ */
+
+const { execSync, spawnSync } = require('child_process');
+const path = require('path');
+
+const MANIFEST_PATH = 'docs/viewer/manifest.json';
+
+function main() {
+  console.log('[docs-manifest] Regenerating manifest due to docs changes...');
+
+  // Run the manifest generator
+  try {
+    execSync('node scripts/generate-docs-manifest.cjs', {
+      cwd: path.join(__dirname, '..'),
+      stdio: 'inherit',
+    });
+  } catch (error) {
+    console.error('[docs-manifest] Manifest generation failed');
+    process.exit(1);
+  }
+
+  // Check if manifest has changes (unstaged)
+  const diffResult = spawnSync('git', ['diff', '--name-only', MANIFEST_PATH], {
+    encoding: 'utf-8',
+    cwd: path.join(__dirname, '..'),
+  });
+
+  const hasDiff = diffResult.stdout.trim().length > 0;
+
+  if (hasDiff) {
+    console.log('[docs-manifest] Manifest changed, staging for commit...');
+    try {
+      execSync(`git add ${MANIFEST_PATH}`, {
+        cwd: path.join(__dirname, '..'),
+        stdio: 'inherit',
+      });
+      console.log('[docs-manifest] Manifest staged successfully');
+    } catch (error) {
+      console.error('[docs-manifest] Failed to stage manifest');
+      process.exit(1);
+    }
+  } else {
+    console.log('[docs-manifest] Manifest unchanged');
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

- Add lint-staged hook to auto-regenerate and stage docs manifest when markdown files in `docs/` change
- Fix CI failure caused by stale manifest (missing REVIEW_TEAM.md entry)

## Problem

When `docs/REVIEW_TEAM.md` was added, the docs manifest was not regenerated before commit. CI caught this as a failure after merge to main.

## Solution

Add an enterprise-grade solution that ensures Local = CI parity (Invariant 33):

1. **New script**: `scripts/regenerate-docs-manifest.cjs` - wrapper that regenerates manifest and auto-stages it
2. **lint-staged hook**: Triggers on `docs/**/*.md` changes, runs before prettier

## How It Works

```
Developer stages docs/*.md → lint-staged detects → regenerate script runs → manifest updated and staged → commit includes both
```

## Test Plan

- [x] Verify script creates and stages manifest when docs change
- [ ] CI passes on this PR
- [ ] Future docs changes auto-include manifest updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)