### PR TITLE
docs: add Meet the Team section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@
 
 ---
 
+## Meet the Team
+
+<a href="docs/REVIEW_TEAM.md">
+  <img src="docs/img/odd-ai-reviewers-banner.png" alt="Meet the AI Review Team" width="600">
+</a>
+
+**[Meet the AI-powered code review team →](docs/REVIEW_TEAM.md)**
+
+---
+
 ## Features
 
 - 🔍 **Multi-Pass Review** — Static analysis first (free), then AI semantic review


### PR DESCRIPTION
Add a new section at the top of README.md featuring the AI review team banner (at 600px width) with a link to docs/REVIEW_TEAM.md where users can learn about each team member.