### PR TITLE
fix(docs-viewer): resolve image paths relative to current document

### DIFF
--- a/docs/viewer/app.js
+++ b/docs/viewer/app.js
@@ -438,11 +438,14 @@ const DocsViewer = {
       }
     });
 
-    // 5. Image Rewriting: Resolve relative images from parent docs dir
+    // 5. Image Rewriting: Resolve relative images from current document's location
+    // Uses the same resolvePath() logic as markdown links to handle nested documents
     container.querySelectorAll('img').forEach((img) => {
       const src = img.getAttribute('src');
       if (src && !src.startsWith('http') && !src.startsWith('data:') && !src.startsWith('/')) {
-        img.src = `${this.basePath}${src}`;
+        // Resolve path relative to current document (e.g., "../img/foo.png" from "reference/review-team.md")
+        const resolvedPath = currentFile ? this.resolvePath(currentFile, src) : src;
+        img.src = `${this.basePath}${resolvedPath}`;
       }
     });
 


### PR DESCRIPTION
Image paths in nested documents (e.g., reference/review-team.md) were broken because the viewer blindly prepended basePath without accounting for the document's depth in the directory tree.

The fix applies the same resolvePath() logic already used for markdown links to image src attributes, ensuring paths like "../img/foo.png" are correctly resolved from the current document's location.