### PR TITLE
Add proximity-based deduplication to handle line drift in comments

### DIFF
--- a/router/src/__tests__/deduplication.test.ts
+++ b/router/src/__tests__/deduplication.test.ts
@@ -326,3 +326,284 @@ describe('Deduplication Regression Fixture', () => {
     expect(deduplicated[0]?.sourceAgent).toBe('semgrep');
   });
 });
+
+/**
+ * Proximity-Based Deduplication Tests
+ *
+ * Tests for the new proximity-based deduplication that handles
+ * the "line drift" problem where code moves between pushes.
+ */
+import {
+  buildProximityMap,
+  isDuplicateByProximity,
+  identifyStaleComments,
+  parseDedupeKey,
+  extractFingerprintFromKey,
+  LINE_PROXIMITY_THRESHOLD,
+  getDedupeKey,
+  generateFingerprint,
+} from '../report/formats.js';
+
+describe('Proximity-Based Deduplication (Line Drift Fix)', () => {
+  describe('parseDedupeKey', () => {
+    it('should parse valid dedupe key', () => {
+      const key = 'abcdef1234567890abcdef1234567890:src/test.ts:42';
+      const parsed = parseDedupeKey(key);
+
+      expect(parsed).not.toBeNull();
+      expect(parsed?.fingerprint).toBe('abcdef1234567890abcdef1234567890');
+      expect(parsed?.file).toBe('src/test.ts');
+      expect(parsed?.line).toBe(42);
+    });
+
+    it('should handle file paths with colons', () => {
+      const key = 'abcdef1234567890abcdef1234567890:C:/Users/test/file.ts:100';
+      const parsed = parseDedupeKey(key);
+
+      expect(parsed).not.toBeNull();
+      expect(parsed?.file).toBe('C:/Users/test/file.ts');
+      expect(parsed?.line).toBe(100);
+    });
+
+    it('should return null for invalid fingerprint', () => {
+      const key = 'invalid:src/test.ts:42';
+      expect(parseDedupeKey(key)).toBeNull();
+    });
+
+    it('should return null for missing line', () => {
+      const key = 'abcdef1234567890abcdef1234567890:src/test.ts';
+      expect(parseDedupeKey(key)).toBeNull();
+    });
+  });
+
+  describe('extractFingerprintFromKey', () => {
+    it('should extract first 32 characters as fingerprint', () => {
+      const key = 'abcdef1234567890abcdef1234567890:src/test.ts:42';
+      expect(extractFingerprintFromKey(key)).toBe('abcdef1234567890abcdef1234567890');
+    });
+  });
+
+  describe('buildProximityMap', () => {
+    it('should group keys by fingerprint+file', () => {
+      const keys = [
+        'abcdef1234567890abcdef1234567890:src/test.ts:10',
+        'abcdef1234567890abcdef1234567890:src/test.ts:15',
+        '12345678901234567890123456789012:src/other.ts:50',
+      ];
+
+      const map = buildProximityMap(keys);
+
+      expect(map.size).toBe(2);
+      expect(map.get('abcdef1234567890abcdef1234567890:src/test.ts')).toEqual([10, 15]);
+      expect(map.get('12345678901234567890123456789012:src/other.ts')).toEqual([50]);
+    });
+
+    it('should handle empty input', () => {
+      const map = buildProximityMap([]);
+      expect(map.size).toBe(0);
+    });
+  });
+
+  describe('isDuplicateByProximity', () => {
+    it('should detect exact match as duplicate', () => {
+      const finding: Finding = {
+        severity: 'error',
+        file: 'src/test.ts',
+        line: 42,
+        message: 'Test issue',
+        sourceAgent: 'semgrep',
+      };
+
+      const key = getDedupeKey(finding);
+      const existingKeys = new Set([key]);
+      const proximityMap = buildProximityMap([key]);
+
+      expect(isDuplicateByProximity(finding, existingKeys, proximityMap)).toBe(true);
+    });
+
+    it('should detect proximity match as duplicate (line drift)', () => {
+      // Simulates: issue was on line 10, now on line 15 (code moved)
+      const finding: Finding = {
+        severity: 'error',
+        file: 'src/test.ts',
+        line: 15, // New line after code moved
+        message: 'Test issue',
+        ruleId: 'test-rule',
+        sourceAgent: 'semgrep',
+      };
+
+      // Generate fingerprint for this finding
+      const fingerprint = generateFingerprint(finding);
+
+      // Existing comment was at line 10 with same fingerprint
+      const existingKey = `${fingerprint}:src/test.ts:10`;
+      const existingKeys = new Set([existingKey]);
+      const proximityMap = buildProximityMap([existingKey]);
+
+      // Should be detected as duplicate because line 15 is within threshold of line 10
+      expect(isDuplicateByProximity(finding, existingKeys, proximityMap)).toBe(true);
+    });
+
+    it('should NOT detect as duplicate if line difference exceeds threshold', () => {
+      const finding: Finding = {
+        severity: 'error',
+        file: 'src/test.ts',
+        line: 100, // Far from existing comment
+        message: 'Test issue',
+        ruleId: 'test-rule',
+        sourceAgent: 'semgrep',
+      };
+
+      const fingerprint = generateFingerprint(finding);
+      // Existing comment was at line 10 - far from line 100
+      const existingKey = `${fingerprint}:src/test.ts:10`;
+      const existingKeys = new Set([existingKey]);
+      const proximityMap = buildProximityMap([existingKey]);
+
+      // Line 100 is more than LINE_PROXIMITY_THRESHOLD away from line 10
+      expect(isDuplicateByProximity(finding, existingKeys, proximityMap)).toBe(false);
+    });
+
+    it('should NOT detect as duplicate for different fingerprint', () => {
+      const finding: Finding = {
+        severity: 'error',
+        file: 'src/test.ts',
+        line: 10,
+        message: 'New different issue',
+        ruleId: 'different-rule',
+        sourceAgent: 'semgrep',
+      };
+
+      // Different fingerprint (different message/rule)
+      const existingKey = 'aaaabbbbccccdddd0000111122223333:src/test.ts:10';
+      const existingKeys = new Set([existingKey]);
+      const proximityMap = buildProximityMap([existingKey]);
+
+      expect(isDuplicateByProximity(finding, existingKeys, proximityMap)).toBe(false);
+    });
+
+    it('should NOT detect as duplicate for different file', () => {
+      const finding: Finding = {
+        severity: 'error',
+        file: 'src/other.ts', // Different file
+        line: 10,
+        message: 'Test issue',
+        ruleId: 'test-rule',
+        sourceAgent: 'semgrep',
+      };
+
+      const fingerprint = generateFingerprint({ ...finding, file: 'src/test.ts' });
+      const existingKey = `${fingerprint}:src/test.ts:10`; // Same fingerprint but different file
+      const existingKeys = new Set([existingKey]);
+      const proximityMap = buildProximityMap([existingKey]);
+
+      expect(isDuplicateByProximity(finding, existingKeys, proximityMap)).toBe(false);
+    });
+  });
+
+  describe('identifyStaleComments', () => {
+    it('should identify comments with no matching findings as stale', () => {
+      // Existing comment for an issue that was fixed
+      const existingKey = 'abcdef1234567890abcdef1234567890:src/test.ts:10';
+
+      // No current findings
+      const currentFindings: Finding[] = [];
+
+      const stale = identifyStaleComments([existingKey], currentFindings);
+      expect(stale).toContain(existingKey);
+    });
+
+    it('should NOT mark comment as stale if finding still exists nearby', () => {
+      const finding: Finding = {
+        severity: 'error',
+        file: 'src/test.ts',
+        line: 15, // Moved from line 10
+        message: 'Test issue',
+        ruleId: 'test-rule',
+        sourceAgent: 'semgrep',
+      };
+
+      const fingerprint = generateFingerprint(finding);
+      const existingKey = `${fingerprint}:src/test.ts:10`; // Old comment at line 10
+
+      const stale = identifyStaleComments([existingKey], [finding]);
+
+      // Should NOT be stale because finding at line 15 is within proximity of line 10
+      expect(stale).not.toContain(existingKey);
+    });
+
+    it('should mark comment as stale if finding moved too far', () => {
+      const finding: Finding = {
+        severity: 'error',
+        file: 'src/test.ts',
+        line: 100, // Moved far from line 10
+        message: 'Test issue',
+        ruleId: 'test-rule',
+        sourceAgent: 'semgrep',
+      };
+
+      const fingerprint = generateFingerprint(finding);
+      const existingKey = `${fingerprint}:src/test.ts:10`; // Old comment at line 10
+
+      const stale = identifyStaleComments([existingKey], [finding]);
+
+      // Should be stale because line 100 is far from line 10
+      expect(stale).toContain(existingKey);
+    });
+
+    it('should handle multiple findings and comments', () => {
+      const findings: Finding[] = [
+        {
+          severity: 'error',
+          file: 'src/a.ts',
+          line: 12, // Moved slightly from 10
+          message: 'Issue A',
+          ruleId: 'rule-a',
+          sourceAgent: 'test',
+        },
+        {
+          severity: 'warning',
+          file: 'src/b.ts',
+          line: 50,
+          message: 'Issue B',
+          ruleId: 'rule-b',
+          sourceAgent: 'test',
+        },
+      ];
+
+      const findingA = findings[0];
+      const findingB = findings[1];
+      if (!findingA || !findingB) throw new Error('Test setup failed');
+      const fingerprintA = generateFingerprint(findingA);
+      const fingerprintB = generateFingerprint(findingB);
+      const fingerprintC = generateFingerprint({
+        severity: 'info',
+        file: 'src/c.ts',
+        line: 1,
+        message: 'Fixed issue',
+        ruleId: 'rule-c',
+        sourceAgent: 'test',
+      });
+
+      const existingKeys = [
+        `${fingerprintA}:src/a.ts:10`, // Issue A was at line 10, now at 12 - NOT stale
+        `${fingerprintB}:src/b.ts:50`, // Issue B exact match - NOT stale
+        `${fingerprintC}:src/c.ts:1`, // Issue C was fixed - STALE
+      ];
+
+      const stale = identifyStaleComments(existingKeys, findings);
+
+      expect(stale).toHaveLength(1);
+      expect(stale[0]).toContain('src/c.ts');
+    });
+  });
+
+  describe('LINE_PROXIMITY_THRESHOLD', () => {
+    it('should be a reasonable value for line drift detection', () => {
+      // Threshold should be reasonable - not too small (misses valid drift)
+      // and not too large (catches unrelated instances)
+      expect(LINE_PROXIMITY_THRESHOLD).toBeGreaterThanOrEqual(10);
+      expect(LINE_PROXIMITY_THRESHOLD).toBeLessThanOrEqual(50);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements proximity-based deduplication to solve the "line drift" problem where security findings move to different line numbers between pushes due to code insertions/deletions. Instead of creating duplicate comments when a finding shifts a few lines, the system now detects these as the same issue and resolves stale comments when issues are fixed.

## Key Changes

- **New deduplication functions in `formats.ts`**:
  - `parseDedupeKey()` - Parse dedupe keys into fingerprint, file, and line components
  - `extractFingerprintFromKey()` - Extract fingerprint hash from dedupe key
  - `buildProximityMap()` - Build a map grouping findings by fingerprint+file with their line numbers
  - `isDuplicateByProximity()` - Check if a finding is a duplicate based on exact match OR proximity match (within `LINE_PROXIMITY_THRESHOLD` lines)
  - `identifyStaleComments()` - Identify comments for issues that no longer exist or moved too far away
  - `LINE_PROXIMITY_THRESHOLD` constant (set to 20 lines) - Configurable threshold for proximity matching

- **Updated `ado.ts` and `github.ts`**:
  - Replace simple fingerprint set with proximity-based deduplication using `isDuplicateByProximity()`
  - Track dedupe keys and map them to comment/thread IDs for resolution
  - Implement stale comment resolution:
    - **GitHub**: Mark stale comments with strikethrough and "✅ Resolved" message
    - **Azure DevOps**: Close stale threads (status = 4)
  - Update logging to report resolved comments/threads

- **Comprehensive test suite** in `deduplication.test.ts`:
  - Tests for parsing and extracting fingerprints from dedupe keys
  - Tests for proximity map building
  - Tests for proximity-based duplicate detection (exact match, line drift, threshold boundaries)
  - Tests for stale comment identification across multiple findings
  - Edge cases: different fingerprints, different files, empty inputs

## Implementation Details

- Dedupe key format: `fingerprint:file:line` where fingerprint is a 32-character hex hash
- Proximity matching uses absolute line difference: `|currentLine - existingLine| <= LINE_PROXIMITY_THRESHOLD`
- Stale comment detection works bidirectionally: checks if existing comments have matching current findings within proximity
- Rate limiting is preserved with `INLINE_COMMENT_DELAY_MS` between API calls
- Graceful error handling for resolution failures with warning logs

https://claude.ai/code/session_011YdKeWv2Dy4jLRawzvET1k