### PR TITLE
fix(release): Disable package-lock for npm version command

### DIFF
--- a/router/.npmrc
+++ b/router/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Root cause: @semantic-release/npm runs `npm version` which tries to update/create package-lock.json in pnpm projects, causing: "Cannot read properties of null (reading 'matches')"

Fix: Add router/.npmrc with package-lock=false to skip lockfile ops.