### PR TITLE
fix(release): disable husky hooks and ignore cache directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          npm_config_package_lock: 'false'
+          HUSKY: '0'
           GIT_AUTHOR_NAME: odd-ai-reviewers-release-bot[bot]
           GIT_AUTHOR_EMAIL: odd-ai-reviewers-release-bot[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: odd-ai-reviewers-release-bot[bot]

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ docs/viewer/playwright-report/
 .claude/
 .codex/
 
+# AI review cache
+.ai-review-cache/
+
 AGENTS.md
 CLAUDE.md
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ coverage/
 package-lock.json
 yarn.lock
 pnpm-lock.yaml
+.ai-review-cache/


### PR DESCRIPTION
- Add HUSKY=0 to release workflow to prevent pre-push hooks from running when semantic-release pushes tags
- Add .ai-review-cache/ to .gitignore and .prettierignore