### PR TITLE
fix(release): remove NPM_TOKEN and add --provenance for OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,6 @@ jobs:
         env:
           DRY_RUN: ${{ inputs.dry_run }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           HUSKY: '0'
           GIT_AUTHOR_NAME: odd-ai-reviewers-release-bot[bot]
           GIT_AUTHOR_EMAIL: odd-ai-reviewers-release-bot[bot]@users.noreply.github.com

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ package-lock.json
 yarn.lock
 pnpm-lock.yaml
 .ai-review-cache/
+CHANGELOG.md

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -50,7 +50,7 @@
       "@semantic-release/exec",
       {
         "prepareCmd": "node -e \"const p=require('./router/package.json');p.version='${nextRelease.version}';require('fs').writeFileSync('./router/package.json',JSON.stringify(p,null,2)+'\\n')\"",
-        "publishCmd": "cd router && pnpm publish --no-git-checks --access public"
+        "publishCmd": "cd router && pnpm publish --no-git-checks --access public --provenance"
       }
     ],
     [


### PR DESCRIPTION
- Remove NPM_TOKEN from workflow (interferes with OIDC auth)
- Add --provenance flag to pnpm publish for OIDC attestation