### PR TITLE
fix(release): wire NODE_AUTH_TOKEN for npm publish authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,8 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-      id-token: write # For npm provenance
+      # id-token: write - Removed for P1 (token-only publish without provenance)
+      # Re-enable in P2 after basic publish is confirmed working
 
     outputs:
       version: ${{ steps.semantic.outputs.new_release_version }}
@@ -65,7 +66,50 @@ jobs:
       - name: Build
         run: pnpm build
 
+      # P1-FR-011: Fail fast if NPM_TOKEN is not configured
+      - name: Verify NPM_TOKEN is set
+        run: |
+          if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+            echo "::error::NPM_TOKEN is not set in the release environment"
+            echo "Please configure NPM_TOKEN in Settings → Environments → release → Environment secrets"
+            exit 1
+          fi
+          echo "✓ NPM_TOKEN is configured"
+
+      # P1-FR-005: Verify npm authentication before publish
+      # This step validates that NODE_AUTH_TOKEN works and registry is correct
+      # Keep permanently until multiple green releases confirm stability
+      - name: Verify npm authentication
+        run: |
+          echo "=== Verifying npm authentication ==="
+
+          # Verify we can authenticate to npm
+          echo "Running npm whoami..."
+          NPM_USER=$(npm whoami 2>&1) || {
+            echo "::error::npm whoami failed - authentication is not working"
+            echo "Verify NPM_TOKEN has publish permission for @oddessentials scope"
+            exit 1
+          }
+          echo "✓ Authenticated as: $NPM_USER"
+
+          # Verify registry URL is correct
+          echo "Checking registry configuration..."
+          REGISTRY=$(npm config get registry)
+          EXPECTED_REGISTRY="https://registry.npmjs.org/"
+          if [ "$REGISTRY" != "$EXPECTED_REGISTRY" ]; then
+            echo "::error::Unexpected registry URL: $REGISTRY (expected: $EXPECTED_REGISTRY)"
+            exit 1
+          fi
+          echo "✓ Registry URL: $REGISTRY"
+
+          echo "=== npm authentication verified successfully ==="
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+
       # FR-009: Dry-run uses identical config
+      # P1-FR-003: NODE_AUTH_TOKEN must be set in the SAME step that runs semantic-release
+      # P1-FR-004: NPM_CONFIG_REGISTRY locks the registry URL
       - name: Semantic Release
         id: semantic
         run: |
@@ -78,6 +122,11 @@ jobs:
         env:
           DRY_RUN: ${{ inputs.dry_run }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # P1-FR-003: npm/pnpm requires NODE_AUTH_TOKEN for authentication
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # P1-FR-004: Lock registry to prevent misdirection
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+          # FR-009: Disable husky hooks during release commits
           HUSKY: '0'
           GIT_AUTHOR_NAME: odd-ai-reviewers-release-bot[bot]
           GIT_AUTHOR_EMAIL: odd-ai-reviewers-release-bot[bot]@users.noreply.github.com

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -50,7 +50,7 @@
       "@semantic-release/exec",
       {
         "prepareCmd": "node -e \"const p=require('./router/package.json');p.version='${nextRelease.version}';require('fs').writeFileSync('./router/package.json',JSON.stringify(p,null,2)+'\\n')\"",
-        "publishCmd": "cd router && pnpm publish --no-git-checks --access public --provenance"
+        "publishCmd": "cd router && pnpm publish --no-git-checks --access public"
       }
     ],
     [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,8 @@ Auto-generated from all feature plans. Last updated: 2026-01-27
 - N/A (stateless CLI) (001-local-review-improvements)
 - TypeScript 5.9.3 (ES2022 target, NodeNext modules), Node.js >=22.0.0 + Commander 14.x (CLI), Zod 4.x (validation), OpenAI SDK 6.x, Anthropic SDK 0.71.x, Octokit 22.x (001-pr-blocking-fixes)
 - N/A (stateless CLI, file-based cache exists but not modified for core fixes) (001-pr-blocking-fixes)
+- GitHub Actions YAML, Bash + semantic-release, @semantic-release/exec, pnpm (408-fix-npm-publish)
+- N/A (CI workflow configuration only) (408-fix-npm-publish)
 
 - TypeScript 5.x (ES2022 target, NodeNext modules), Node.js >=22.0.0 (001-control-flow-analysis)
 - N/A (ephemeral workspace per constitution) (001-control-flow-analysis)
@@ -66,9 +68,9 @@ tests/
 Markdown documentation (no code changes): Follow standard conventions
 
 ## Recent Changes
+- 408-fix-npm-publish: Added GitHub Actions YAML, Bash + semantic-release, @semantic-release/exec, pnpm
 - 001-pr-blocking-fixes: Added TypeScript 5.9.3 (ES2022 target, NodeNext modules), Node.js >=22.0.0 + Commander 14.x (CLI), Zod 4.x (validation), OpenAI SDK 6.x, Anthropic SDK 0.71.x, Octokit 22.x
 - 001-local-review-improvements: Added TypeScript 5.9.3 (ES2022 target, NodeNext modules) + Commander.js 14.x (CLI), Zod 4.x (validation), Node.js ≥22.0.0
-- 016-semantic-release: Added TypeScript 5.9.x (ES2022 target, NodeNext modules) + semantic-release (core), @semantic-release/changelog, @semantic-release/git, @semantic-release/npm, @semantic-release/github, commitlint (existing)
 
 
 

--- a/specs/408-fix-npm-publish/checklists/requirements.md
+++ b/specs/408-fix-npm-publish/checklists/requirements.md
@@ -1,0 +1,59 @@
+# Specification Quality Checklist: Fix npm Release Authentication
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-04
+**Updated**: 2026-02-04 (FINAL - all safeguards integrated)
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified (E404 masking, auth verification, registry locking, empty token, wrong directory, plugin override)
+- [x] Scope is clearly bounded (P1 vs P2 staged rollout)
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+- [x] Staged rollout strategy defined (P1 token-only, P2 provenance)
+
+## Final Directives (verbatim implementation required)
+
+- [x] NPM_TOKEN ONLY in "release" environment; DELETE from repository secrets
+- [x] Job must declare `environment: release`
+- [x] NODE_AUTH_TOKEN set in SAME step as semantic-release
+- [x] Lock registry with NPM_CONFIG_REGISTRY=https://registry.npmjs.org/
+- [x] Verify auth with `npm whoami` + `npm config get registry`; fail if either fails
+- [x] P1 forbids --provenance, id-token: write, and all provenance config
+
+## Final Safeguards (last critical checks)
+
+- [x] Ensure semantic-release performs publish (not pnpm directly elsewhere)
+- [x] Verify plugin config does NOT override env/registry
+- [x] Working directory correctness: set `working-directory: router` or `pkgRoot`
+- [x] Auth verification permanent until multiple green releases
+- [x] Empty token guard: error if `${{ secrets.NPM_TOKEN }}` is empty at runtime
+- [x] Test strategy: dry-run first, then real publish
+
+## Outcome Guarantee
+
+Implemented verbatim, this spec produces either:
+
+- **(a)** Successful publish to npm
+- **(b)** Deterministic failure pointing to single remaining variable
+
+**Status**: READY FOR `/speckit.plan`

--- a/specs/408-fix-npm-publish/plan.md
+++ b/specs/408-fix-npm-publish/plan.md
@@ -1,0 +1,132 @@
+# Implementation Plan: Fix npm Release Authentication
+
+**Branch**: `408-fix-npm-publish` | **Date**: 2026-02-04 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/408-fix-npm-publish/spec.md`
+
+## Summary
+
+Fix the E404 npm publish failure by properly wiring npm authentication. The root cause is that `NODE_AUTH_TOKEN` is not set in the semantic-release step, causing pnpm to run unauthenticated. npm returns E404 (masking 403) for scoped packages when authentication fails.
+
+**P1 Approach**: Token-only publish (no provenance) to isolate authentication as the single variable.
+**P2 Approach**: Re-enable provenance after P1 succeeds.
+
+## Technical Context
+
+**Language/Version**: GitHub Actions YAML, Bash
+**Primary Dependencies**: semantic-release, @semantic-release/exec, pnpm
+**Storage**: N/A (CI workflow configuration only)
+**Testing**: Manual trigger via workflow_dispatch with dry_run option
+**Target Platform**: GitHub Actions (ubuntu-latest)
+**Project Type**: CI/CD configuration change
+**Performance Goals**: N/A
+**Constraints**: Must not break existing release automation; changes must be backward-compatible
+**Scale/Scope**: Single workflow file + single config file
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+### Pre-Research Check (Phase 0)
+
+| Principle                        | Status   | Notes                                                           |
+| -------------------------------- | -------- | --------------------------------------------------------------- |
+| I. Router Owns All Posting       | N/A      | No PR posting involved                                          |
+| II. Structured Findings Contract | N/A      | No agent findings                                               |
+| III. Provider-Neutral Core       | N/A      | CI config only                                                  |
+| IV. Security-First Design        | **PASS** | NPM_TOKEN only in protected environment; no new secret exposure |
+| V. Deterministic Outputs         | **PASS** | Workflow produces deterministic publish                         |
+| VI. Bounded Resources            | **PASS** | No unbounded operations                                         |
+| VII. Environment Discipline      | **PASS** | Using pinned Node.js, frozen lockfile                           |
+| VIII. Explicit Non-Goals         | **PASS** | Not becoming CI runner                                          |
+
+**GATE STATUS**: ✅ PASS
+
+### Post-Design Check (Phase 1)
+
+| Principle                   | Status   | Notes                                                                                          |
+| --------------------------- | -------- | ---------------------------------------------------------------------------------------------- |
+| IV. Security-First Design   | **PASS** | Design enforces: token only in environment, explicit auth verification, no new secret exposure |
+| V. Deterministic Outputs    | **PASS** | Auth verification provides deterministic failure on misconfig                                  |
+| VII. Environment Discipline | **PASS** | No new runtime installers; using existing pinned toolchain                                     |
+
+**GATE STATUS**: ✅ PASS - No violations introduced by design
+
+**Quality Gates**:
+
+- Zero-Tolerance Lint Policy: N/A (YAML config)
+- Security Linting: N/A
+- Dependency Architecture: N/A
+- Local = CI Parity: N/A (CI-only change)
+
+**Verification Requirements**:
+
+- PR Merge Criteria: Manual verification of successful npm publish
+- Release Criteria: npm registry shows new version with expected metadata
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/408-fix-npm-publish/
+├── spec.md              # Feature specification (complete)
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # N/A (no data model)
+├── quickstart.md        # Phase 1 output
+├── contracts/           # N/A (no API contracts)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (files to modify)
+
+```text
+.github/workflows/
+└── release.yml          # P1: Add auth verification, NODE_AUTH_TOKEN, remove provenance
+                         # P2: Re-add --provenance (separate PR after P1 succeeds)
+
+.releaserc.json          # P1: Remove --provenance from publishCmd
+                         # P2: Re-add --provenance (separate PR)
+```
+
+**Structure Decision**: Minimal CI configuration change. Only two files affected.
+
+## Complexity Tracking
+
+No constitution violations to justify.
+
+## File Changes Summary
+
+### P1 Changes (Token-Only Publish)
+
+#### `.github/workflows/release.yml`
+
+1. **Remove `id-token: write`** from permissions (line 29)
+2. **Add empty token guard step** before semantic-release
+3. **Add auth verification step** (`npm whoami`, `npm config get registry`)
+4. **Add `NODE_AUTH_TOKEN`** to semantic-release step env
+5. **Add `NPM_CONFIG_REGISTRY`** to semantic-release step env
+
+#### `.releaserc.json`
+
+1. **Remove `--provenance`** from publishCmd (line 53)
+
+### P2 Changes (Re-enable Provenance) - Separate PR after P1 succeeds
+
+#### `.github/workflows/release.yml`
+
+1. Re-add `id-token: write` permission
+2. Keep all P1 auth verification (permanent)
+
+#### `.releaserc.json`
+
+1. Re-add `--provenance` to publishCmd
+
+## Manual Action Required
+
+**CRITICAL**: Before merging P1, the user must:
+
+1. **Delete NPM_TOKEN from repository secrets** (if present)
+2. **Verify NPM_TOKEN exists in "release" environment** only
+
+This cannot be automated and must be done via GitHub Settings UI.

--- a/specs/408-fix-npm-publish/quickstart.md
+++ b/specs/408-fix-npm-publish/quickstart.md
@@ -1,0 +1,169 @@
+# Quickstart: Fix npm Release Authentication
+
+**Feature**: 408-fix-npm-publish
+**Date**: 2026-02-04
+
+## Prerequisites
+
+Before implementing this fix:
+
+1. **Verify NPM_TOKEN exists in "release" environment**
+   - Go to: Repository Settings → Environments → release → Environment secrets
+   - Confirm `NPM_TOKEN` is listed
+
+2. **Delete NPM_TOKEN from repository secrets** (if present)
+   - Go to: Repository Settings → Secrets and variables → Actions → Repository secrets
+   - Delete `NPM_TOKEN` if it exists (should only be in environment)
+
+## P1 Implementation Steps
+
+### Step 1: Update release.yml
+
+Edit `.github/workflows/release.yml`:
+
+1. **Remove `id-token: write` permission** (line 29)
+
+   ```yaml
+   # Before
+   permissions:
+     contents: write
+     issues: write
+     pull-requests: write
+     id-token: write # For npm provenance
+
+   # After
+   permissions:
+     contents: write
+     issues: write
+     pull-requests: write
+     # id-token: write removed for P1 (no provenance)
+   ```
+
+2. **Add empty token guard step** (after Build step)
+
+   ```yaml
+   - name: Verify NPM_TOKEN is set
+     run: |
+       if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+         echo "ERROR: NPM_TOKEN is not set in the release environment"
+         exit 1
+       fi
+       echo "✓ NPM_TOKEN is set"
+   ```
+
+3. **Add auth verification step** (after token guard)
+
+   ```yaml
+   - name: Verify npm authentication
+     run: |
+       echo "Verifying npm authentication..."
+       npm whoami
+       echo "✓ npm whoami succeeded"
+
+       REGISTRY=$(npm config get registry)
+       echo "Registry: $REGISTRY"
+       if [ "$REGISTRY" != "https://registry.npmjs.org/" ]; then
+         echo "ERROR: Unexpected registry URL"
+         exit 1
+       fi
+       echo "✓ Registry URL verified"
+     env:
+       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+       NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+   ```
+
+4. **Update semantic-release step env** (add NODE_AUTH_TOKEN and NPM_CONFIG_REGISTRY)
+   ```yaml
+   - name: Semantic Release
+     id: semantic
+     run: |
+       if [[ "$DRY_RUN" == "true" ]]; then
+         echo "Running in dry-run mode..."
+         pnpm exec semantic-release --dry-run
+       else
+         pnpm exec semantic-release
+       fi
+     env:
+       DRY_RUN: ${{ inputs.dry_run }}
+       GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+       NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+       HUSKY: '0'
+       GIT_AUTHOR_NAME: odd-ai-reviewers-release-bot[bot]
+       GIT_AUTHOR_EMAIL: odd-ai-reviewers-release-bot[bot]@users.noreply.github.com
+       GIT_COMMITTER_NAME: odd-ai-reviewers-release-bot[bot]
+       GIT_COMMITTER_EMAIL: odd-ai-reviewers-release-bot[bot]@users.noreply.github.com
+   ```
+
+### Step 2: Update .releaserc.json
+
+Edit `.releaserc.json`:
+
+1. **Remove `--provenance` from publishCmd** (line 53)
+
+   ```json
+   // Before
+   "publishCmd": "cd router && pnpm publish --no-git-checks --access public --provenance"
+
+   // After
+   "publishCmd": "cd router && pnpm publish --no-git-checks --access public"
+   ```
+
+### Step 3: Test with Dry Run
+
+1. Push changes to feature branch
+2. Create PR to main
+3. After merge, manually trigger release workflow with `dry_run: true`
+4. Verify:
+   - Empty token guard passes
+   - `npm whoami` succeeds
+   - `npm config get registry` returns correct URL
+   - semantic-release dry-run completes without error
+
+### Step 4: Real Publish
+
+1. Trigger release workflow without dry_run (or push a `fix:` commit to main)
+2. Verify:
+   - All verification steps pass
+   - Package publishes to npm without E404
+   - Version appears on npmjs.com
+
+## P2 Implementation (After P1 Succeeds)
+
+In a separate PR after P1 is confirmed working:
+
+1. **Re-add `id-token: write` permission** in release.yml
+2. **Re-add `--provenance` to publishCmd** in .releaserc.json
+3. Verify provenance attestation appears on npm package page
+
+## Troubleshooting
+
+### E404 still occurs
+
+- Verify `NODE_AUTH_TOKEN` is set (check `npm whoami` output)
+- Verify registry URL is correct (check `npm config get registry` output)
+- Verify NPM_TOKEN has publish permission for `@oddessentials` scope
+
+### npm whoami fails
+
+- NPM_TOKEN may be invalid or expired
+- Token may not have correct permissions
+- Generate new token with automation type and publish access
+
+### Wrong registry
+
+- Check `NPM_CONFIG_REGISTRY` is set correctly
+- Ensure no `.npmrc` file overrides the registry
+
+## Verification Checklist
+
+- [ ] NPM_TOKEN only in "release" environment
+- [ ] NPM_TOKEN deleted from repository secrets
+- [ ] `id-token: write` removed from permissions
+- [ ] Empty token guard step added
+- [ ] Auth verification step added
+- [ ] `NODE_AUTH_TOKEN` added to semantic-release env
+- [ ] `NPM_CONFIG_REGISTRY` added to semantic-release env
+- [ ] `--provenance` removed from publishCmd
+- [ ] Dry run succeeds
+- [ ] Real publish succeeds

--- a/specs/408-fix-npm-publish/research.md
+++ b/specs/408-fix-npm-publish/research.md
@@ -1,0 +1,105 @@
+# Research: Fix npm Release Authentication
+
+**Feature**: 408-fix-npm-publish
+**Date**: 2026-02-04
+
+## Overview
+
+All technical questions were resolved during specification clarification. This document consolidates the findings.
+
+## Research Findings
+
+### 1. npm Authentication for Scoped Packages
+
+**Decision**: Use `NODE_AUTH_TOKEN` environment variable
+
+**Rationale**:
+
+- pnpm and npm CLI both read `NODE_AUTH_TOKEN` for authentication
+- `NPM_TOKEN` alone is insufficient; must be explicitly mapped to `NODE_AUTH_TOKEN`
+- The `actions/setup-node` action with `registry-url` creates `.npmrc` that uses `NODE_AUTH_TOKEN`
+
+**Alternatives Considered**:
+
+- `NPM_TOKEN` only: Rejected - pnpm does not automatically read this variable
+- `.npmrc` file committed to repo: Rejected - security risk, not needed with env var approach
+
+### 2. E404 Error Behavior
+
+**Decision**: E404 indicates authentication failure (not missing package)
+
+**Rationale**:
+
+- npm registry returns 404 instead of 403 for scoped packages to avoid leaking package existence
+- This is intentional security behavior by npm
+- Package @oddessentials/odd-ai-reviewers v1.0.0 already exists on npm
+
+**Alternatives Considered**:
+
+- Treating as registry issue: Rejected - registry is functioning correctly
+- Creating new package: Rejected - package exists, just auth is failing
+
+### 3. Provenance and OIDC
+
+**Decision**: Remove provenance for P1, re-enable as P2
+
+**Rationale**:
+
+- `--provenance` adds extra failure modes (OIDC token issues, `id-token: write` permission)
+- Isolating authentication first eliminates confounding variables
+- Provenance is valuable but secondary to basic publish functionality
+
+**Alternatives Considered**:
+
+- Keeping provenance in P1: Rejected - conflates multiple failure modes
+- Removing provenance permanently: Rejected - supply chain security is valuable
+
+### 4. Secret Storage Location
+
+**Decision**: NPM_TOKEN only in "release" environment
+
+**Rationale**:
+
+- Environment-scoped secrets provide additional protection
+- Job must explicitly declare `environment: release` to access
+- Prevents accidental token exposure in other workflows
+
+**Alternatives Considered**:
+
+- Repository-level secret: Rejected - less secure, can be accessed by any workflow
+- Both locations: Rejected - redundant and confusing
+
+### 5. Working Directory
+
+**Decision**: Publish from `router/` subdirectory via `cd router` in publishCmd
+
+**Rationale**:
+
+- Package lives in `router/` subdirectory
+- Current `.releaserc.json` already uses `cd router && pnpm publish`
+- No change needed; current approach is correct
+
+**Alternatives Considered**:
+
+- `pkgRoot` config: Not needed - `cd router` works
+- `working-directory` in workflow: Not needed - semantic-release handles it
+
+### 6. Auth Verification Strategy
+
+**Decision**: Run `npm whoami` and `npm config get registry` before publish
+
+**Rationale**:
+
+- Fails fast with clear error message if auth is misconfigured
+- `npm whoami` verifies token is valid and has correct scope
+- `npm config get registry` verifies correct registry URL
+- Permanent until multiple green releases confirm stability
+
+**Alternatives Considered**:
+
+- Relying on pnpm publish error: Rejected - error messages are cryptic (E404)
+- Single check only: Rejected - both checks provide different validation
+
+## No NEEDS CLARIFICATION Remaining
+
+All technical questions resolved. Ready for Phase 1 design.

--- a/specs/408-fix-npm-publish/spec.md
+++ b/specs/408-fix-npm-publish/spec.md
@@ -1,0 +1,174 @@
+# Feature Specification: Fix npm Release Authentication
+
+**Feature Branch**: `408-fix-npm-publish`
+**Created**: 2026-02-04
+**Status**: Ready for Planning
+**Input**: User description: "Fix npm release - E404 error publishing @oddessentials/odd-ai-reviewers due to authentication failure"
+
+## Clarifications
+
+### Session 2026-02-04
+
+- Q: What is the root cause of E404 on publish? → A: npm masks auth/permission failures as E404 for scoped packages; the workflow is missing NODE_AUTH_TOKEN (not just NPM_TOKEN)
+- Q: Should provenance be bundled with P1? → A: No. P1 = token-only publish without --provenance. P2 = re-enable provenance after P1 succeeds
+- Q: Is NPM_TOKEN configured? → A: Yes, configured in both release environment and as repo secret with full publish permissions for @oddessentials scope
+- Q: What environment variable does pnpm/npm require? → A: NODE_AUTH_TOKEN must be explicitly set; NPM_TOKEN alone is insufficient
+- Q: Where should NPM_TOKEN be stored? → A: ONLY in GitHub Actions "release" environment; DELETE from repository secrets
+- Q: How to verify auth before publish? → A: Run `npm whoami` and `npm config get registry`; fail job immediately if either fails
+- Q: How to lock registry? → A: Set NPM_CONFIG_REGISTRY=https://registry.npmjs.org/ in release job
+- Q: Who performs the actual publish? → A: semantic-release (via @semantic-release/exec or @semantic-release/npm); confirm plugin config does NOT override env/registry
+- Q: How to handle package in subdirectory? → A: Explicitly set `working-directory` for release step OR configure `pkgRoot` in semantic-release config
+- Q: Should auth verification be permanent? → A: Keep `npm whoami` and `npm config get registry` permanently; remove only after multiple green releases
+- Q: How to guard against empty token? → A: Add explicit guard that errors if `${{ secrets.NPM_TOKEN }}` is empty at runtime
+- Q: Recommended test strategy? → A: First run semantic-release with --dry-run (P1 config) to verify tags/versioning, then run without dry-run to publish
+
+## Assumptions
+
+- Package @oddessentials/odd-ai-reviewers v1.0.0 is already published to npm
+- The E404 error occurs during the publish of subsequent versions (e.g., v1.0.1)
+- E404 is npm masking an authentication/authorization failure, not a missing package
+- NPM_TOKEN is a valid automation token with publish permissions for @oddessentials scope
+- Package lives in `router/` subdirectory (requires explicit working-directory or pkgRoot)
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Basic Token-Only Publish (Priority: P1)
+
+A maintainer merges code to the main branch that triggers a semantic-release version bump. The release workflow should successfully publish the new version to npm using token authentication only, without provenance signing.
+
+**Why this priority**: Must prove basic publish works before adding provenance complexity. Provenance adds extra failure modes that can mask the underlying auth issue. Token-only publish isolates authentication as the sole variable.
+
+**Independent Test**: Can be fully tested by triggering a release workflow with `--provenance` flag removed and verifying the new version appears on npmjs.com.
+
+**Acceptance Scenarios**:
+
+1. **Given** the package v1.0.0 already exists on npm registry, **When** a release is triggered with a version bump (provenance disabled), **Then** the new version is successfully published to npm
+2. **Given** NODE_AUTH_TOKEN is set from NPM_TOKEN in the semantic-release step, **When** pnpm publish runs, **Then** npm authenticates successfully and returns 200 (not E404)
+3. **Given** the workflow targets the "release" environment, **When** the publish step executes, **Then** the NPM_TOKEN secret is available at runtime
+4. **Given** auth verification step runs before publish, **When** `npm whoami` or `npm config get registry` fails, **Then** the job fails immediately before attempting publish
+5. **Given** NPM_TOKEN might be empty/unset, **When** the job starts, **Then** a guard check fails fast with clear error message before any publish attempt
+6. **Given** semantic-release --dry-run is executed first, **When** tags/versioning are verified, **Then** the real publish run proceeds
+
+---
+
+### User Story 2 - Publish with Provenance (Priority: P2)
+
+After P1 is proven working, re-enable provenance signing to provide supply chain security attestation.
+
+**Why this priority**: Provenance is valuable but adds complexity. Must only be re-enabled after basic publish is confirmed working to avoid debugging multiple failure modes simultaneously.
+
+**Independent Test**: Can be tested by re-adding `--provenance` flag after P1 succeeds and verifying provenance attestation appears on npm.
+
+**Acceptance Scenarios**:
+
+1. **Given** P1 (token-only publish) succeeds, **When** --provenance flag is re-enabled, **Then** the package publishes with provenance attestation
+2. **Given** id-token: write permission is configured, **When** the publish runs with --provenance, **Then** the provenance statement is signed via OIDC and published to transparency log
+
+---
+
+### User Story 3 - Pre-commit Hooks Disabled During Release (Priority: P3)
+
+The release workflow should not be blocked by husky pre-commit hooks when semantic-release creates the release commit.
+
+**Why this priority**: This prevents release failures due to hook interference, but is a supporting concern rather than core functionality.
+
+**Independent Test**: Can be tested by verifying the release workflow completes even when husky hooks are configured in the repository.
+
+**Acceptance Scenarios**:
+
+1. **Given** husky pre-commit hooks are configured, **When** semantic-release creates a release commit, **Then** the hooks are skipped and the commit succeeds
+2. **Given** HUSKY environment variable is set to '0', **When** git operations run during release, **Then** no husky hooks execute
+
+---
+
+### Edge Cases
+
+- What happens when NODE_AUTH_TOKEN is not set (only NPM_TOKEN)?
+  - pnpm/npm publish runs unauthenticated; npm returns E404 (masking 403) for scoped package
+- What happens when NPM_TOKEN has insufficient scope permissions?
+  - npm returns E404 (not 403) to avoid leaking package existence information
+- What happens when workflow doesn't target the "release" environment?
+  - Secrets are unavailable; publish fails silently with auth error
+- What happens when --provenance is used but OIDC permissions are wrong?
+  - Publish may fail with cryptic error that looks like auth failure; isolate by testing without provenance first
+- What happens when `npm whoami` fails before publish?
+  - Job fails immediately with clear auth failure message before attempting publish
+- What happens when registry URL is wrong or not locked?
+  - Auth may succeed against wrong registry; lock registry explicitly to prevent misdirection
+- What happens when NPM_TOKEN secret is empty at runtime?
+  - Guard check fails fast with explicit "NPM_TOKEN is empty" error before any npm commands run
+- What happens when publish runs from wrong directory?
+  - Auth/404 noise; ensure working-directory is set to `router/` or pkgRoot is configured
+- What happens when semantic-release plugin overrides env/registry?
+  - Auth may fail despite correct workflow config; verify plugin config does not override NODE_AUTH_TOKEN or registry
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+**P1 - Token-Only Publish (must complete first)**
+
+- **FR-001**: NPM_TOKEN MUST exist ONLY in the GitHub Actions "release" environment; DELETE from repository secrets
+- **FR-002**: Release job MUST declare `environment: release` to bind to the environment
+- **FR-003**: NODE_AUTH_TOKEN MUST be set to `${{ secrets.NPM_TOKEN }}` in the SAME step that runs semantic-release
+- **FR-004**: Release job MUST set `NPM_CONFIG_REGISTRY=https://registry.npmjs.org/` to lock the registry
+- **FR-005**: Release workflow MUST run `npm whoami` and `npm config get registry` before publish; if EITHER fails, fail the job immediately
+- **FR-006**: P1 implementation MUST remove `--provenance` flag from publish command
+- **FR-007**: P1 implementation MUST remove `id-token: write` permission from job
+- **FR-008**: P1 implementation MUST remove any provenance-related configuration
+- **FR-009**: Release workflow MUST maintain HUSKY='0' environment variable to disable git hooks
+- **FR-010**: Publish command MUST include --access public for scoped package
+- **FR-011**: Release workflow MUST add explicit guard that errors if `${{ secrets.NPM_TOKEN }}` is empty at runtime
+- **FR-012**: Release step MUST set `working-directory: router` OR semantic-release config MUST set `pkgRoot: router`
+- **FR-013**: Verify semantic-release plugin config does NOT override NODE_AUTH_TOKEN or NPM_CONFIG_REGISTRY
+- **FR-014**: Auth verification (`npm whoami`, `npm config get registry`) MUST remain permanently until multiple green releases confirm stability
+- **FR-015**: First P1 deployment SHOULD use semantic-release --dry-run to verify tags/versioning before real publish
+
+**P2 - Re-enable Provenance (only after P1 succeeds)**
+
+- **FR-016**: After P1 is verified working, re-add --provenance flag to publish command
+- **FR-017**: After P1 is verified working, re-add id-token: write permission for OIDC provenance signing
+- **FR-018**: Provenance must not be bundled with P1; it is a separate, subsequent change
+
+### Key Entities
+
+- **NODE_AUTH_TOKEN**: The environment variable that pnpm/npm CLI uses for authentication; must be set explicitly in the semantic-release step
+- **NPM_TOKEN**: GitHub secret containing npm automation token with publish permissions for @oddessentials scope; stored ONLY in "release" environment (not repository secrets)
+- **NPM_CONFIG_REGISTRY**: Environment variable locking the npm registry URL to https://registry.npmjs.org/
+- **Release Environment**: GitHub Actions environment named "release" that contains NPM_TOKEN; job must declare `environment: release`
+- **Auth Verification**: Pre-publish check using `npm whoami` and `npm config get registry` that fails the job if either command fails; permanent until multiple green releases
+- **Empty Token Guard**: Explicit check that `${{ secrets.NPM_TOKEN }}` is non-empty before any npm commands execute
+- **Working Directory**: The `router/` subdirectory where package.json lives; must be explicitly set via `working-directory` or `pkgRoot`
+- **Provenance Attestation**: Cryptographic proof linking published package to source (P2 only, not P1)
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+**P1 Success (must be achieved first)**
+
+- **SC-001**: Empty token guard executes and passes (token is non-empty)
+- **SC-002**: `npm whoami` succeeds and returns expected user/automation account
+- **SC-003**: `npm config get registry` returns https://registry.npmjs.org/
+- **SC-004**: semantic-release --dry-run completes without error (first deployment)
+- **SC-005**: Release workflow publishes v1.0.1+ to npm without E404 or authentication errors (provenance disabled)
+- **SC-006**: npm registry shows new version available within 5 minutes of workflow completion
+
+**P2 Success (only after P1)**
+
+- **SC-007**: After P1 succeeds, re-enabling --provenance results in successful publish with attestation
+- **SC-008**: Published packages show provenance attestation verifiable on npmjs.com
+
+**General**
+
+- **SC-009**: Release commits created by semantic-release complete without husky hook interference
+- **SC-010**: The verify job confirms version synchronization across package.json, git tag, npm registry, and CHANGELOG
+
+## Implementation Outcome Guarantee
+
+If this spec is implemented **verbatim**, the result will be one of:
+
+- **(a)** Successful publish to npm
+- **(b)** Deterministic failure pointing to a single remaining variable
+
+Either way, guessing stops here.

--- a/specs/408-fix-npm-publish/tasks.md
+++ b/specs/408-fix-npm-publish/tasks.md
@@ -1,0 +1,195 @@
+# Tasks: Fix npm Release Authentication
+
+**Input**: Design documents from `/specs/408-fix-npm-publish/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, quickstart.md
+
+**Tests**: Not applicable - this is a CI configuration change. Testing is via workflow_dispatch dry_run.
+
+**Organization**: Tasks are grouped by user story (P1 = token-only publish, P2 = provenance). P3 (HUSKY) is already implemented in current workflow.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+Files to modify:
+
+- `.github/workflows/release.yml`
+- `.releaserc.json`
+
+---
+
+## Phase 1: Manual Prerequisites (User Action Required)
+
+**Purpose**: Secret configuration that cannot be automated
+
+**⚠️ CRITICAL**: These MUST be completed via GitHub UI before any code changes
+
+- [ ] T001 Verify NPM_TOKEN exists in "release" environment (Settings → Environments → release → Environment secrets)
+- [ ] T002 Delete NPM_TOKEN from repository secrets if present (Settings → Secrets and variables → Actions)
+
+**Checkpoint**: NPM_TOKEN exists ONLY in "release" environment
+
+---
+
+## Phase 2: User Story 1 - Token-Only Publish (Priority: P1) 🎯 MVP
+
+**Goal**: Fix npm publish authentication by properly wiring NODE_AUTH_TOKEN and removing provenance
+
+**Independent Test**: Trigger workflow with `dry_run: true`, verify `npm whoami` and `npm config get registry` succeed
+
+### Implementation for User Story 1
+
+#### Part A: Workflow Changes (.github/workflows/release.yml)
+
+- [ ] T003 [US1] Remove `id-token: write` from permissions block (line 29) in .github/workflows/release.yml
+- [ ] T004 [US1] Add "Verify NPM_TOKEN is set" guard step after Build step in .github/workflows/release.yml
+- [ ] T005 [US1] Add "Verify npm authentication" step with npm whoami and registry check in .github/workflows/release.yml
+- [ ] T006 [US1] Add NODE_AUTH_TOKEN and NPM_CONFIG_REGISTRY to semantic-release step env in .github/workflows/release.yml
+
+#### Part B: Semantic Release Config (.releaserc.json)
+
+- [ ] T007 [P] [US1] Remove --provenance flag from publishCmd in .releaserc.json
+
+**Checkpoint**: P1 code changes complete - ready for PR
+
+---
+
+## Phase 3: User Story 1 Verification (P1 Validation)
+
+**Goal**: Prove P1 fix works before enabling provenance
+
+**Independent Test**: Successful npm publish without E404
+
+- [ ] T008 [US1] Create PR with P1 changes and merge to main
+- [ ] T009 [US1] Trigger release workflow with dry_run=true and verify all checks pass
+- [ ] T010 [US1] Trigger release workflow (real publish) and verify package publishes to npm
+
+**Checkpoint**: P1 validated - package successfully published to npm without E404
+
+---
+
+## Phase 4: User Story 2 - Re-enable Provenance (Priority: P2)
+
+**Goal**: Re-add provenance signing after P1 is confirmed working
+
+**Depends on**: P1 must succeed (T010 complete) before starting P2
+
+**Independent Test**: npm package shows provenance attestation after publish
+
+### Implementation for User Story 2
+
+- [ ] T011 [US2] Re-add `id-token: write` permission in .github/workflows/release.yml
+- [ ] T012 [P] [US2] Re-add --provenance flag to publishCmd in .releaserc.json
+- [ ] T013 [US2] Create PR with P2 changes and merge to main
+- [ ] T014 [US2] Trigger release and verify provenance attestation appears on npmjs.com
+
+**Checkpoint**: P2 validated - package publishes with provenance attestation
+
+---
+
+## Phase 5: Polish & Documentation
+
+**Purpose**: Ensure permanent auth verification and documentation
+
+- [ ] T015 Verify auth verification steps (npm whoami, npm config get registry) remain in workflow permanently
+- [ ] T016 Update quickstart.md verification checklist with actual test results
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+```
+Phase 1 (Manual)
+    ↓
+Phase 2 (P1 Code Changes)
+    ↓
+Phase 3 (P1 Verification) ← STOP HERE if P1 fails
+    ↓
+Phase 4 (P2 Code Changes) ← Only if P1 succeeds
+    ↓
+Phase 5 (Polish)
+```
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: No dependencies on other stories - can start after Phase 1 manual steps
+- **User Story 2 (P2)**: **DEPENDS ON P1 SUCCESS** - Must not start until P1 is verified working (T010 complete)
+
+### Task Dependencies Within P1
+
+```
+T003 → T004 → T005 → T006 (sequential within release.yml)
+T007 can run in parallel with T003-T006 (different file)
+T008 depends on T003-T007 (all code changes complete)
+T009 depends on T008 (PR merged)
+T010 depends on T009 (dry run verified)
+```
+
+### Parallel Opportunities
+
+Within P1 implementation (Phase 2):
+
+- T007 (.releaserc.json) can run in parallel with T003-T006 (.github/workflows/release.yml)
+
+Within P2 implementation (Phase 4):
+
+- T011 (release.yml) and T012 (.releaserc.json) can run in parallel
+
+---
+
+## Parallel Example: User Story 1 (P1)
+
+```bash
+# These can run in parallel (different files):
+Task T003-T006: "Modify .github/workflows/release.yml"
+Task T007: "Modify .releaserc.json"
+
+# Then sequentially:
+Task T008: "Create PR and merge"
+Task T009: "Dry run verification"
+Task T010: "Real publish verification"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (P1 Only)
+
+1. ✅ Complete Phase 1: Manual Prerequisites
+2. ✅ Complete Phase 2: P1 Code Changes
+3. ✅ Complete Phase 3: P1 Verification
+4. **STOP**: If P1 succeeds, you have a working release pipeline
+5. **OPTIONAL**: Continue to P2 for provenance
+
+### Staged Rollout (Recommended)
+
+1. P1 PR → merge → verify publish works
+2. Wait for 1-2 successful releases with P1
+3. P2 PR → merge → verify provenance works
+4. Keep auth verification permanent
+
+### Rollback Plan
+
+If P1 still fails:
+
+- Check `npm whoami` output in workflow logs
+- Check `npm config get registry` output
+- Verify NPM_TOKEN has correct permissions
+- Error should be deterministic and point to single variable
+
+---
+
+## Notes
+
+- **No code tests**: This is CI configuration; testing is via workflow execution
+- **P2 is separate PR**: Do not bundle provenance with P1
+- **Auth verification is permanent**: Keep npm whoami and npm config get registry until multiple green releases
+- **Manual steps first**: T001-T002 must be done via GitHub UI before any code changes
+- **Stop on failure**: If P1 verification fails, debug before attempting P2


### PR DESCRIPTION
## Summary

- Wire `NODE_AUTH_TOKEN` and `NPM_CONFIG_REGISTRY` to semantic-release step env
- Add auth verification steps (`npm whoami`, registry check) before publish
- Add fail-fast guard for empty `NPM_TOKEN`
- Remove `--provenance` flag for P1 (token-only publish)
- Remove `id-token: write` permission (not needed without provenance)

## Root Cause

npm returns E404 (masking 403) for scoped packages when authentication fails. `NODE_AUTH_TOKEN` was not set in the semantic-release step, causing pnpm to run unauthenticated.

## Test Plan

- [ ] Verify `NPM_TOKEN` exists ONLY in "release" environment (not repo secrets)
- [ ] Merge PR to main
- [ ] Trigger workflow with `dry_run: true` - verify `npm whoami` succeeds
- [ ] Trigger real release - verify package publishes without E404

## P2 (Follow-up)

After P1 is validated with successful publishes, re-enable provenance in a separate PR.

Refs: #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)