### PR TITLE
feat(release): enable npm provenance attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-      # id-token: write - Removed for P1 (token-only publish without provenance)
-      # Re-enable in P2 after basic publish is confirmed working
+      id-token: write # Required for npm provenance OIDC signing
 
     outputs:
       version: ${{ steps.semantic.outputs.new_release_version }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -50,7 +50,7 @@
       "@semantic-release/exec",
       {
         "prepareCmd": "node -e \"const p=require('./router/package.json');p.version='${nextRelease.version}';require('fs').writeFileSync('./router/package.json',JSON.stringify(p,null,2)+'\\n')\"",
-        "publishCmd": "cd router && pnpm publish --no-git-checks --access public"
+        "publishCmd": "cd router && pnpm publish --no-git-checks --access public --provenance"
       }
     ],
     [


### PR DESCRIPTION
## Summary

P2 follow-up to P1 auth fix (#133). Re-enables supply chain security features:

- Add `id-token: write` permission for OIDC signing
- Add `--provenance` flag to pnpm publish command

## What is Provenance?

Provenance creates a cryptographic attestation that proves:
- Package was built from a specific GitHub commit
- Build ran on GitHub Actions (verifiable)
- Links npm package to source repository

## Test Plan

- [ ] Merge PR to main
- [ ] Verify release workflow succeeds
- [ ] Check npm package page shows "Provenance" badge

## Prerequisites

P1 validated with successful v1.0.2 publish.

Refs: #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)