### PR TITLE
fix: remove workflow credential gate that bypassed router preflight

### DIFF
--- a/.github/workflows/ai-review-dispatch.yml
+++ b/.github/workflows/ai-review-dispatch.yml
@@ -70,7 +70,7 @@ jobs:
         env:
           BASE_REF: ${{ inputs.base_ref }}
         run: |
-          echo "sha=$(git rev-parse "origin/$BASE_REF")" >> $GITHUB_OUTPUT
+          echo "sha=$(git rev-parse "origin/$BASE_REF")" >> "$GITHUB_OUTPUT"
 
       - name: Run AI Review
         env:
@@ -85,18 +85,17 @@ jobs:
           OWNER=$(echo "$TARGET_REPO" | cut -d'/' -f1)
           REPO=$(echo "$TARGET_REPO" | cut -d'/' -f2)
 
-          PR_ARG=""
-          if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "0" ]; then
-            PR_ARG="--pr $PR_NUMBER"
-          fi
-
-          node router/dist/main.js review \
-            --repo target \
+          set -- --repo target \
             --base "$BASE_SHA" \
             --head "$TARGET_REF" \
             --owner "$OWNER" \
-            --repo-name "$REPO" \
-            $PR_ARG
+            --repo-name "$REPO"
+
+          if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "0" ]; then
+            set -- "$@" --pr "$PR_NUMBER"
+          fi
+
+          node router/dist/main.js review "$@"
 
       - name: Upload results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -120,18 +120,6 @@ jobs:
             echo "sha=$(git rev-parse "origin/$INPUT_BASE_REF")" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Validate AI credentials
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OLLAMA_BASE_URL: ${{ secrets.OLLAMA_BASE_URL }}
-          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
-        run: |
-          if [ -z "$OPENAI_API_KEY" ] && [ -z "$ANTHROPIC_API_KEY" ] && [ -z "$OLLAMA_BASE_URL" ] && [ -z "$AZURE_OPENAI_API_KEY" ]; then
-            echo "::error::No AI credentials provided. Pass secrets with 'secrets: inherit' or map OPENAI_API_KEY, ANTHROPIC_API_KEY, AZURE_OPENAI_API_KEY, or OLLAMA_BASE_URL in the calling workflow."
-            exit 1
-          fi
-
       - name: Run AI Review
         working-directory: router
         env:
@@ -150,18 +138,17 @@ jobs:
           OWNER=$(echo "$INPUT_TARGET_REPO" | cut -d'/' -f1)
           REPO=$(echo "$INPUT_TARGET_REPO" | cut -d'/' -f2)
 
-          PR_FLAG=""
-          if [ -n "$INPUT_PR_NUMBER" ]; then
-            PR_FLAG="--pr $INPUT_PR_NUMBER"
-          fi
-
-          node router/dist/main.js review \
-            --repo ../target \
+          set -- --repo ../target \
             --base "$BASE_SHA" \
             --head "$INPUT_TARGET_REF" \
             --owner "$OWNER" \
-            --repo-name "$REPO" \
-            $PR_FLAG
+            --repo-name "$REPO"
+
+          if [ -n "$INPUT_PR_NUMBER" ]; then
+            set -- "$@" --pr "$INPUT_PR_NUMBER"
+          fi
+
+          node router/dist/main.js review "$@"
 
       - name: Upload review artifacts
         uses: actions/upload-artifact@v4

--- a/router/src/preflight.ts
+++ b/router/src/preflight.ts
@@ -482,15 +482,21 @@ export function validateModelProviderMatch(
   }
 
   // Heuristic: infer provider from model prefix
+  // Use explicit empty-string checks (consistent with validateAgentSecrets and
+  // validateExplicitProviderKeys) — GitHub Actions sets missing secrets to ''
+  const keyPresent = (key: string): boolean => {
+    const v = env[key];
+    return v !== undefined && v.trim() !== '';
+  };
+
   if (model.startsWith('claude-')) {
-    if (!env['ANTHROPIC_API_KEY']) {
+    if (!keyPresent('ANTHROPIC_API_KEY')) {
       errors.push(
         `MODEL '${model}' looks like Anthropic (claude-*) but ANTHROPIC_API_KEY is missing`
       );
     }
   } else if (model.startsWith('gpt-') || model.startsWith('o1-')) {
-    const hasOpenAI = env['OPENAI_API_KEY'] || env['AZURE_OPENAI_API_KEY'];
-    if (!hasOpenAI) {
+    if (!keyPresent('OPENAI_API_KEY') && !keyPresent('AZURE_OPENAI_API_KEY')) {
       errors.push(`MODEL '${model}' looks like OpenAI (gpt-*/o1-*) but OPENAI_API_KEY is missing`);
     }
   }


### PR DESCRIPTION
## Summary

- **Removes the "Validate AI credentials" workflow step** that hard-failed (`exit 1`) when all four credential env vars were empty, before the router could apply its config-aware preflight validation
- **Normalizes empty-string checks** in `validateModelProviderMatch` to use the explicit `env[key] !== undefined && trim() !== ''` pattern matching all other validators
- **Hardens shell quoting** in both `ai-review.yml` and `ai-review-dispatch.yml` — replaces unquoted `$PR_FLAG`/`$PR_ARG` with the safe `set -- "$@"` array pattern, quotes `$GITHUB_OUTPUT`

## Context

The credential gate was introduced in #149 as a fail-fast guard. After #150 added config-aware `pass.required` semantics to the router's preflight, the workflow gate became actively harmful:

1. **Static-only configs** (semgrep + reviewdog, no cloud keys) — gate kills the run even though the router would succeed
2. **Optional cloud passes** (`required: false`, the default) — gate kills the run before the router can demote missing keys to warnings and skip the optional pass
3. **Dependabot PRs** — GitHub secret isolation means all secrets are empty in Dependabot context; gate always fires

The router's `runPreflightChecks()` is the authoritative, config-aware validation layer. It already handles all credential validation with proper context (which agents are enabled, which passes are required, which providers are configured).

## Test plan

- [x] `pnpm build` — TypeScript compilation passes
- [x] `pnpm test` — 137 files, 3620 tests pass
- [x] Pre-commit hooks pass (Prettier + ESLint --max-warnings 0)
- [x] Pre-push quality gates pass (lint, format, TypeScript, dependency analysis, docs linkcheck, full test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)